### PR TITLE
Remove body from event when setting request headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,10 @@ function getPathWithQueryStringParams(event) {
 function mapApiGatewayEventToHttpRequest(event, context, socketPath) {
     const headers = event.headers || {}
 
-    headers['x-apigateway-event'] = JSON.stringify(event)
+    const eventWithoutBody = Object.assign({}, event)
+    delete eventWithoutBody['body']
+
+    headers['x-apigateway-event'] = JSON.stringify(eventWithoutBody)
     headers['x-apigateway-context'] = JSON.stringify(context)
 
     return {


### PR DESCRIPTION
`mapApiGatewayEventToHttpRequest` inserts the entire event, including the body of the original request, into the HTTP request headers. If the event includes a large JSON body or a file, the HTTP request will fail if using default Node max header size (80kb). This PL removes the event body from the HTTP request headers. 
