### PR TITLE
changed increment socket name to use unix timestamp

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,10 +106,14 @@ function getSocketPath(socketPathSuffix) {
     return `/tmp/server${socketPathSuffix}.sock`
 }
 
+function socketTimestamp () {
+    return (new Date()).valueOf(); //unix epoch ms
+}
+
 exports.createServer = (requestListener, serverListenCallback) => {
     const server = http.createServer(requestListener)
 
-    server._socketPathSuffix = 0
+    server._socketPathSuffix = socketTimestamp()
     server.on('listening', () => {
         server._isListening = true
 
@@ -121,7 +125,7 @@ exports.createServer = (requestListener, serverListenCallback) => {
     .on('error', (err) => {
         if (err.code === 'EADDRINUSE') {
             console.warn(`EADDRINUSE ${getSocketPath(server._socketPathSuffix)} incrementing socketPathSuffix.`)
-            ++server._socketPathSuffix
+            server._socketPathSuffix = socketTimestamp()
             server.close(() => startServer(server))
         }
     })


### PR DESCRIPTION
Thanks for this very helpful module. We're using it to set up a (relatively) high performance JSON API, and keep running into an issue in Lambda where socket ports are still in use:

EADDRINUSE /tmp/server0.sock incrementing socketPathSuffix.
EADDRINUSE /tmp/server1.sock incrementing socketPathSuffix.
EADDRINUSE /tmp/server2.sock incrementing socketPathSuffix.
EADDRINUSE /tmp/server3.sock incrementing socketPathSuffix.
EADDRINUSE /tmp/server4.sock incrementing socketPathSuffix.
EADDRINUSE /tmp/server5.sock incrementing socketPathSuffix.
...

Not sure what the problem is, or if others are having similar issues, but we forked and started using unix timestamps instead of incrementing integers, and we don't see it happen anymore.