### PR TITLE
API Gateway proxy integration decodes URL parameters 

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function getPathWithQueryStringParams(event) {
 
     if (queryStringKeys.length === 0) return event.path
 
-    const queryStringParams = queryStringKeys.map(queryStringKey => `${queryStringKey}=${event.queryStringParameters[queryStringKey]}`).join('&')
+    const queryStringParams = queryStringKeys.map(queryStringKey => `${queryStringKey}=${encodeURIComponent(event.queryStringParameters[queryStringKey])}`).join('&')
 
     return `${event.path}?${queryStringParams}`
 }


### PR DESCRIPTION
...before passing them to lambda, so it's necessary to re-encode them before making the request locally.

While express will subsequently decode them again before putting them into req.query for the application, this is still necessary in cases where parameters have been encoded multiple times, or where the parameter contains encoded & characters which would split it into multiple parameters.

A case that illustrates this problem is where your request is like this:

`/path?foo=1&url=http%3A%2F%2Fexample.com%3Fnested%3D1&bar=2`


