### PR TITLE
Binary support for API Gateway.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,11 @@
+{
+  "esversion": 6,
+  "node": true,
+  "asi": true,
+  "globals": {
+    /* jest */
+    "test": false,
+    "expect": false,
+    "describe": false
+  }
+}

--- a/README.md
+++ b/README.md
@@ -84,5 +84,4 @@ app.use(awsServerlessExpressMiddleware.eventContext())
  - Cannot use native libraries (aka [Addons](https://nodejs.org/api/addons.html)) unless you package your app on an EC2 machine running Amazon Linux
  - Stateless only
  - Multiple headers with same name not supported
- - Currently no support for binary data
  - API Gateway has a timeout of 30 seconds, and Lambda has a maximum execution time of 5 minutes.

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -83,3 +83,89 @@ test('getSocketPath', () => {
     const socketPath = awsServerlessExpress.getSocketPath(0)
     expect(socketPath).toEqual('/tmp/server0.sock')
 })
+
+describe('forwardResponseToApiGateway: content-type encoding', () => {
+    const PassThrough = require('stream').PassThrough
+
+    class MockResponse extends PassThrough {
+        constructor(statusCode, headers, body) {
+            super()
+            this.statusCode = statusCode
+            this.headers = headers || {}
+            this.write(body)
+            this.end()
+        }
+    }
+
+    class MockServer {
+        constructor(binaryTypes) {
+            this._binaryTypes = binaryTypes || []
+        }
+    }
+
+    class MockContext {
+        constructor(resolve) {
+            this.resolve = resolve
+        }
+        succeed(successResponse) {
+            this.resolve(successResponse)
+        }
+    }
+
+    test('content-type header missing', () => {
+        const server = new MockServer()
+        const headers = {'foo': 'bar'}
+        const body = 'hello world'
+        const response = new MockResponse(200, headers, body)
+        return new Promise(
+            (resolve, reject) => {
+                const context = new MockContext(resolve)
+                awsServerlessExpress.forwardResponseToApiGateway(
+                    server, response, context)
+            }
+        ).then(successResponse => expect(successResponse).toEqual({
+            statusCode: 200,
+            body: body,
+            headers: headers,
+            isBase64Encoded: false
+        }))
+    })
+
+    test('content-type image/jpeg base64 encoded', () => {
+        const server = new MockServer(['image/jpeg'])
+        const headers = {'content-type': 'image/jpeg'}
+        const body = 'hello world'
+        const response = new MockResponse(200, headers, body)
+        return new Promise(
+            (resolve, reject) => {
+                const context = new MockContext(resolve)
+                awsServerlessExpress.forwardResponseToApiGateway(
+                    server, response, context)
+            }
+        ).then(successResponse => expect(successResponse).toEqual({
+            statusCode: 200,
+            body: new Buffer(body).toString('base64'),
+            headers: headers,
+            isBase64Encoded: true
+        }))
+    })
+
+    test('content-type application/json', () => {
+        const server = new MockServer()
+        const headers = {'content-type': 'application/json'}
+        const body = JSON.stringify({'hello': 'world'})
+        const response = new MockResponse(200, headers, body)
+        return new Promise(
+            (resolve, reject) => {
+                const context = new MockContext(resolve)
+                awsServerlessExpress.forwardResponseToApiGateway(
+                    server, response, context)
+            }
+        ).then(successResponse => expect(successResponse).toEqual({
+            statusCode: 200,
+            body: body,
+            headers: headers,
+            isBase64Encoded: false
+        }))
+    })
+})


### PR DESCRIPTION
* base64 encode user given binary types, e.g. 'image/jpeg'
* binary types must match the ones configured in API Gateway Binary Support media types
* using 'isBase64Encoded' flag and client given 'Accept' -header API Gateway will base64 decode the content