### PR TITLE
support multiple headers with the same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,4 @@ app.use(awsServerlessExpressMiddleware.eventContext())
  - May be more expensive for high-traffic apps
  - Cannot use native libraries (aka [Addons](https://nodejs.org/api/addons.html)) unless you package your app on an EC2 machine running Amazon Linux
  - Stateless only
- - Multiple headers with same name not currently supported
  - API Gateway has a timeout of 30 seconds, and Lambda has a maximum execution time of 5 minutes.

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@
  */
 'use strict'
 const http = require('http')
+const binarycase = require('binary-case');
 
 function getPathWithQueryStringParams(event) {
     const queryStringKeys = Object.keys(event.queryStringParameters || {})
@@ -57,7 +58,12 @@ function forwardResponseToApiGateway(server, response, context) {
 
             Object.keys(headers)
                 .forEach(h => {
-                    if(Array.isArray(headers[h])) headers[h] = headers[h].join(',')
+                    if(Array.isArray(headers[h])) {
+                      headers[h].forEach((value, i) => {
+                        headers[binarycase(h, i + 1)] = value;
+                      });
+                      delete headers[h];
+                    }
                 })
 
             const contentType = headers['content-type']

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   },
   "scripts": {
     "test": "jest"
+  },
+  "dependencies": {
+    "binary-case": "^1.0.0"
   }
 }


### PR DESCRIPTION
Original credit goes to [Gi60s](https://forums.aws.amazon.com/message.jspa?messageID=750798#750798)

Iterating over headers that are arrays and transforming their key name to it's different case versions makes LAMBDA_PROXY return all of them.

Brilliant.