### PR TITLE
Adding support for gzip responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,9 +42,21 @@ function mapApiGatewayEventToHttpRequest(event, context, socketPath) {
 }
 
 function forwardResponseToApiGateway(server, response, context) {
+    const gunzip = require('zlib').createGunzip()
     let buf = []
 
-    response
+    let parsedResponse = null
+    
+    if (response.headers['content-encoding'] == "gzip") {
+        response.pipe(gunzip)
+        parsedResponse = gunzip
+        response.headers['content-encoding'] = undefined
+        response.headers['transfer-encoding'] = undefined
+    } else {
+        parsedResponse = response
+    }
+    
+    parsedResponse
         .on('data', (chunk) => buf.push(chunk))
         .on('end', () => {
             let body = Buffer.concat(buf)


### PR DESCRIPTION
Trying to resolve the problem related at #45 I've found out that requests bigger than 1kb were being treated as gzipped.
So I added support to it in order to accept larger responses. =)