### PR TITLE
renaming err as error to log createServer errors correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,8 +153,8 @@ function createServer (requestListener, serverListenCallback, binaryTypes) {
     server.on('close', () => {
         server._isListening = false
     })
-    .on('error', (err) => {
-        if (err.code === 'EADDRINUSE') {
+    .on('error', (error) => {
+        if (error.code === 'EADDRINUSE') {
             console.warn(`EADDRINUSE ${getSocketPath(server._socketPathSuffix)} incrementing socketPathSuffix.`)
             ++server._socketPathSuffix
             return server.close(() => startServer(server))


### PR DESCRIPTION
err is defined as "err" but being logged to the console as "error" on line 164