### PR TITLE
Don't create server if it was already created earlier.

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,10 @@ function getSocketPath(socketPathSuffix) {
 }
 
 function createServer (requestListener, serverListenCallback, binaryTypes) {
-    const server = http.createServer(requestListener)
+    let server = requestListener
+    if (typeof(requestListener) === 'function') {
+        server = http.createServer(requestListener)
+    }
 
     server._socketPathSuffix = 0
     server._binaryTypes = binaryTypes ? binaryTypes.slice() : []


### PR DESCRIPTION
Hello,

I'd like to suggest the pull request. It is about not creating `http` server if it was already created. I faced with this problem when I tried to use Restify with this library.