### PR TITLE
close server after context succeed

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,10 @@ function forwardResponseToApiGateway(server, response, context) {
             const body = bodyBuffer.toString(isBase64Encoded ? 'base64' : 'utf8')
             const successResponse = {statusCode, body, headers, isBase64Encoded}
 
-            context.succeed(successResponse)
+            context.succeed(successResponse);
+            if (server && server.close) {
+                server.close();
+            }
         })
 }
 
@@ -98,6 +101,9 @@ function forwardConnectionErrorResponseToApiGateway(server, error, context) {
     }
 
     context.succeed(errorResponse)
+    if (server && server.close) {
+        server.close();
+    }
 }
 
 function forwardLibraryErrorResponseToApiGateway(server, error, context) {
@@ -110,6 +116,9 @@ function forwardLibraryErrorResponseToApiGateway(server, error, context) {
     }
 
     context.succeed(errorResponse)
+    if (server && server.close) {
+        server.close();
+    }
 }
 
 function forwardRequestToNodeServer(server, event, context) {


### PR DESCRIPTION
This PR is in response to https://github.com/awslabs/aws-serverless-express/issues/91 an issue that our organization experiences as well. 

In our case, we are using serverless framework with the "serverless-offline" plugin that spins up the service in our local environment and serves multiple requests. I think the expectation in lambda is a single request being serviced per process but in some local dev configurations a single process might be servicing multiple requests. For example we do local dredd API testing which starts serverless offline and calls all of our REST endpoints before shutting down serverless. 

To recreate the issue:
  * install serverless
  * create serverless hello world template
  * install serverless-offline plugin
  * install expressjs
  * install aws-serverless-express

Serverless config 
```yaml
service: serverless-hello-world

# The `provider` block defines where your service will be deployed
provider:
  name: aws
  runtime: nodejs6.10

plugins:
  - serverless-offline

# The `functions` block defines what code to deploy
functions:
  helloWorld:
    handler: handler.helloWorld
    # The `events` block defines how to trigger the handler.helloWorld code
    events:
      - http:
          path: hello-world
          method: get
          cors: true
```

Serverless handler
```js
'use strict';

const express = require('express');
const app = express();

app.get('/hello-world', function (req, res) {
  res.send('Hello World!')
});


const awsServerlessExpress = require('aws-serverless-express');

const server = awsServerlessExpress.createServer(app);

exports.helloWorld = (event, context, callback) => awsServerlessExpress.proxy(server, event, context);
```

Test your service locally:
```
$ sls offline start
Serverless: Starting Offline: dev/us-east-1.

Serverless: Routes for helloWorld:
Serverless: GET /hello-world

Serverless: Offline listening on http://localhost:3000
```

Hit your endpoint multiple times:
```
curl -v http://localhost:3000/hello-world
curl -v http://localhost:3000/hello-world
curl -v http://localhost:3000/hello-world
```

Observe warnings:
```
Serverless: GET /hello-world (λ: helloWorld)
Serverless: The first request might take a few extra seconds
Serverless: [200] {"statusCode":200,"body":"Hello World!","headers":{"x-powered-by":"Express","content-type":"text/html; charset=utf-8","content-length":"12","etag":"W/\"c-Lve95gjOVATpfV8EL5X4nxwjKHE\"","date":"Sun, 08 Oct 2017 19:00:36 GMT","connection":"close"},"isBase64Encoded":false}

Serverless: GET /hello-world (λ: helloWorld)
WARNING: Attempting to listen on socket /tmp/server0.sock, but it is already in use. This is likely as a result of a previous invocation error or timeout. Check the logs for the invocation(s) immediately prior to this for root cause, and consider increasing the timeout and/or cpu/memory allocation if this is purely as a result of a timeout. aws-serverless-express will restart the Node.js server listening on a new port and continue with this request.
Serverless: [200] {"statusCode":200,"body":"Hello World!","headers":{"x-powered-by":"Express","content-type":"text/html; charset=utf-8","content-length":"12","etag":"W/\"c-Lve95gjOVATpfV8EL5X4nxwjKHE\"","date":"Sun, 08 Oct 2017 19:00:37 GMT","connection":"close"},"isBase64Encoded":false}

Serverless: GET /hello-world (λ: helloWorld)
WARNING: Attempting to listen on socket /tmp/server0.sock, but it is already in use. This is likely as a result of a previous invocation error or timeout. Check the logs for the invocation(s) immediately prior to this for root cause, and consider increasing the timeout and/or cpu/memory allocation if this is purely as a result of a timeout. aws-serverless-express will restart the Node.js server listening on a new port and continue with this request.
WARNING: Attempting to listen on socket /tmp/server1.sock, but it is already in use. This is likely as a result of a previous invocation error or timeout. Check the logs for the invocation(s) immediately prior to this for root cause, and consider increasing the timeout and/or cpu/memory allocation if this is purely as a result of a timeout. aws-serverless-express will restart the Node.js server listening on a new port and continue with this request.
Serverless: [200] {"statusCode":200,"body":"Hello World!","headers":{"x-powered-by":"Express","content-type":"text/html; charset=utf-8","content-length":"12","etag":"W/\"c-Lve95gjOVATpfV8EL5X4nxwjKHE\"","date":"Sun, 08 Oct 2017 19:00:38 GMT","connection":"close"},"isBase64Encoded":false}
```



With the change the PR applies, we simply call close on server after `context.succeed` is called.

Re-run local test and hit the endpoint multiple times and observe the warning is no longer present.
```
Serverless: GET /hello-world (λ: helloWorld)
Serverless: The first request might take a few extra seconds
Serverless: [200] {"statusCode":200,"body":"Hello World!","headers":{"x-powered-by":"Express","content-type":"text/html; charset=utf-8","content-length":"12","etag":"W/\"c-Lve95gjOVATpfV8EL5X4nxwjKHE\"","date":"Sun, 08 Oct 2017 19:03:02 GMT","connection":"close"},"isBase64Encoded":false}

Serverless: GET /hello-world (λ: helloWorld)
Serverless: [200] {"statusCode":200,"body":"Hello World!","headers":{"x-powered-by":"Express","content-type":"text/html; charset=utf-8","content-length":"12","etag":"W/\"c-Lve95gjOVATpfV8EL5X4nxwjKHE\"","date":"Sun, 08 Oct 2017 19:03:02 GMT","connection":"close"},"isBase64Encoded":false}

Serverless: GET /hello-world (λ: helloWorld)
Serverless: [200] {"statusCode":200,"body":"Hello World!","headers":{"x-powered-by":"Express","content-type":"text/html; charset=utf-8","content-length":"12","etag":"W/\"c-Lve95gjOVATpfV8EL5X4nxwjKHE\"","date":"Sun, 08 Oct 2017 19:03:03 GMT","connection":"close"},"isBase64Encoded":false}

Serverless: GET /hello-world (λ: helloWorld)
Serverless: [200] {"statusCode":200,"body":"Hello World!","headers":{"x-powered-by":"Express","content-type":"text/html; charset=utf-8","content-length":"12","etag":"W/\"c-Lve95gjOVATpfV8EL5X4nxwjKHE\"","date":"Sun, 08 Oct 2017 19:03:03 GMT","connection":"close"},"isBase64Encoded":false}
```
