### PR TITLE
Close socket when running locally

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,10 @@ function forwardResponseToApiGateway(server, response, context) {
             const body = bodyBuffer.toString(isBase64Encoded ? 'base64' : 'utf8')
             const successResponse = {statusCode, body, headers, isBase64Encoded}
 
-            context.succeed(successResponse)
+            context.succeed(successResponse);
+            if (context.local && server && server.close) {
+                server.close();
+            }
         })
 }
 
@@ -98,6 +101,9 @@ function forwardConnectionErrorResponseToApiGateway(server, error, context) {
     }
 
     context.succeed(errorResponse)
+    if (context.local && server && server.close) {
+        server.close();
+    }
 }
 
 function forwardLibraryErrorResponseToApiGateway(server, error, context) {
@@ -110,6 +116,9 @@ function forwardLibraryErrorResponseToApiGateway(server, error, context) {
     }
 
     context.succeed(errorResponse)
+    if (context.local && server && server.close) {
+        server.close();
+    }
 }
 
 function forwardRequestToNodeServer(server, event, context) {


### PR DESCRIPTION
This is the same PR as https://github.com/awslabs/aws-serverless-express/pull/103

But is meant to work with https://github.com/motdotla/node-lambda/ using the flag added in this PR: https://github.com/motdotla/node-lambda/pull/405

Should fix: #91 