### PR TITLE
Replace node server with mock-http objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "binary-case": "^1.0.0"
+    "binary-case": "^1.0.0",
+    "mock-http": "0.0.10"
   }
 }


### PR DESCRIPTION
* Bring in mock-http so that we can use their mocks of http.ClientRequest and http.ServerResponse as arguments to a RequestListener, which express implements
* Rework `proxy()` flow to accommodate this, while maintaining some semblance of API backwards compatibility
* `createServer()` now just returns the given request listener with `_binaryTypes` added to it. This allows it to be supplied to `proxy()` instead of a full HTTP server. `serverListenCallback` will be invoked immediately, given that there are no servers involved now and technically requests can be immediately processed
* `proxy()` now takes in the `binaryTypes` argument, so that one can just proxy the request listener, event, context and optional binary types directly without having to invoke `createServer()` first. If `binaryTypes` is undefined, `proxy()` will fall back on `requestListener._binaryTypes`. This allows existing users of aws-serverless-express to upgrade their library without worrying about breaking changes.
* Remove now-redundant functions relating to HTTP server lifecycle

Dispensing with the http server allows us to avoid the associated spin up time to open and attach to a socket, allowing us to process requests much sooner.

This PR should also fix all requests relating to socket errors, and supersede their corresponding PRs.