### PR TITLE
Updated README with observations on api-gateway limitations regarding gzip

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ app.get('/', (req, res) => {
 
 #### Cons
 
+ - Gzip compression is not supported by AWS's api-gateway ( encoding a response with Gzip causes error 330 ERR_CONTENT_DECODING_FAILED )
  - For apps that may not see traffic for several minutes at a time, you could see [cold starts](https://aws.amazon.com/blogs/compute/container-reuse-in-lambda/)
  - Cannot use native libraries (aka [Addons](https://nodejs.org/api/addons.html)) unless you package your app on an EC2 machine running Amazon Linux
  - Stateless only


### PR DESCRIPTION
AWS's api-gateway does not support Gzip encoding, this is poorly documented and can cause a lot of trouble for developers, we should make it as clear as possible for all developers of api-gateway's limitations.