### PR TITLE
randomize socket suffix

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -91,8 +91,8 @@ test('mapApiGatewayEventToHttpRequest: without headers', () => {
 })
 
 test('getSocketPath', () => {
-    const socketPath = awsServerlessExpress.getSocketPath(0)
-    expect(socketPath).toEqual('/tmp/server0.sock')
+    const socketPath = awsServerlessExpress.getSocketPath('12345abcdef')
+    expect(socketPath).toEqual('/tmp/server-12345abcdef.sock')
 })
 
 const PassThrough = require('stream').PassThrough

--- a/index.js
+++ b/index.js
@@ -139,17 +139,21 @@ function startServer(server) {
 function getSocketPath(socketPathSuffix) {
   if (/^win/.test(process.platform)) {
     const path = require('path')
-    return path.join('\\\\?\\pipe', process.cwd(), `server${socketPathSuffix}`)
+    return path.join('\\\\?\\pipe', process.cwd(), `server-${socketPathSuffix}`)
   }
   else {
-    return `/tmp/server${socketPathSuffix}.sock`
+    return `/tmp/server-${socketPathSuffix}.sock`
   }
+}
+
+function getRandomString() {
+    return Math.random().toString(36).substring(2, 15)
 }
 
 function createServer (requestListener, serverListenCallback, binaryTypes) {
     const server = http.createServer(requestListener)
 
-    server._socketPathSuffix = 0
+    server._socketPathSuffix = getRandomString()
     server._binaryTypes = binaryTypes ? binaryTypes.slice() : []
     server.on('listening', () => {
         server._isListening = true
@@ -162,7 +166,7 @@ function createServer (requestListener, serverListenCallback, binaryTypes) {
     .on('error', (error) => {
         if (error.code === 'EADDRINUSE') {
             console.warn(`WARNING: Attempting to listen on socket ${getSocketPath(server._socketPathSuffix)}, but it is already in use. This is likely as a result of a previous invocation error or timeout. Check the logs for the invocation(s) immediately prior to this for root cause, and consider increasing the timeout and/or cpu/memory allocation if this is purely as a result of a timeout. aws-serverless-express will restart the Node.js server listening on a new port and continue with this request.`)
-            ++server._socketPathSuffix
+            server._socketPathSuffix = getRandomString()
             return server.close(() => startServer(server))
         }
 


### PR DESCRIPTION
*Issue #, if available:*

#109, #5

*Description of changes:*

Replaced `socketPathSuffix` with random value (generated by `getRandomValue()`).

Currently, it is a number that increments when `EADDRINUSE` occurs. This implementation may cause a lot of warnings when combined with specific libraries such as `serverless-offline`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
