### PR TITLE
example/lambda - init server once per context

### DIFF
--- a/example/lambda.js
+++ b/example/lambda.js
@@ -25,6 +25,13 @@ const binaryMimeTypes = [
   'text/text',
   'text/xml'
 ]
-const server = awsServerlessExpress.createServer(app, null, binaryMimeTypes)
-
-exports.handler = (event, context) => awsServerlessExpress.proxy(server, event, context)
+exports.handler = (event, context) => {
+	const serverPromise = context.serverPromise || 
+		Promise.resolve().then(() => awsServerlessExpress.createServer(app, null, binaryMimeTypes))
+	if (!context.serverPromise) {
+		context.serverPromise = serverPromise
+	}
+	const contextWithoutServerPromise = Object.assign({}, context)
+	delete contextWithoutServerPromise.serverPromise
+	serverPromise.then(server => awsServerlessExpress.proxy(server, event, contextWithoutServerPromise))
+}


### PR DESCRIPTION
*Description of changes:*
The given example will create one http.Server _per lambda invocation_. This introduces significant delay, and for spiky traffic, would result in http.Server objects being thrown away when the excess lambda instances are removed.

This change attempts to improve things by storing an http.Server wrapped in a Promise in the execution context provided by AWS Lambda. The first lambda invocation will create the serverPromise and save it in the context. Subsequent invocations can then use this.

Given node assumes there is only a single thread of execution, it is obvious that there would be a race condition between two lambda invocations in creating and saving the serverPromise. This should only be a minor problem since the server itself is stateless and can be easily replaced without consequence.

`serverPromise` is removed from a copy of the context before the event and that copied context is proxied to the server, in order to prevent it from being serialized to string (and hence triggering an error relating to JSON circular structures)

*Declaration*
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
