### PR TITLE
feat: support wildcards and extensions in binary types

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -200,4 +200,42 @@ describe('forwardResponseToApiGateway: content-type encoding', () => {
             isBase64Encoded: false
         }))
     })
+
+    test('wildcards in binary types array', () => {
+        const server = new MockServer(['image/*'])
+        const headers = {'content-type': 'image/jpeg'}
+        const body = 'hello world'
+        const response = new MockResponse(200, headers, body)
+        return new Promise(
+            (resolve, reject) => {
+                const context = new MockContext(resolve)
+                awsServerlessExpress.forwardResponseToApiGateway(
+                    server, response, context)
+            }
+        ).then(successResponse => expect(successResponse).toEqual({
+            statusCode: 200,
+            body: new Buffer(body).toString('base64'),
+            headers: headers,
+            isBase64Encoded: true
+        }))
+    })
+
+    test('extensions in binary types array', () => {
+        const server = new MockServer(['.png'])
+        const headers = {'content-type': 'image/png'}
+        const body = 'hello world'
+        const response = new MockResponse(200, headers, body)
+        return new Promise(
+            (resolve, reject) => {
+                const context = new MockContext(resolve)
+                awsServerlessExpress.forwardResponseToApiGateway(
+                    server, response, context)
+            }
+        ).then(successResponse => expect(successResponse).toEqual({
+            statusCode: 200,
+            body: new Buffer(body).toString('base64'),
+            headers: headers,
+            isBase64Encoded: true
+        }))
+    })
 })

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function getContentType(params) {
 }
 
 function isContentTypeBinaryMimeType(params) {
-  return params.binaryMimeTypes.length > 0 && !!isType.is(params.contentType, params.binaryMimeTypes);
+  return params.binaryMimeTypes.length > 0 && !!isType.is(params.contentType, params.binaryMimeTypes)
 }
 
 function mapApiGatewayEventToHttpRequest(event, context, socketPath) {

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@
 const http = require('http')
 const url = require('url')
 const binarycase = require('binary-case')
+const isType = require('type-is')
 
 function getPathWithQueryStringParams(event) {
   return url.format({ pathname: event.path, query: event.queryStringParameters })
@@ -27,7 +28,7 @@ function getContentType(params) {
 }
 
 function isContentTypeBinaryMimeType(params) {
-  return params.binaryMimeTypes.indexOf(params.contentType) !== -1
+  return Boolean(params.binaryMimeTypes.length && isType.is(params.contentType, params.binaryMimeTypes));
 }
 
 function mapApiGatewayEventToHttpRequest(event, context, socketPath) {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function getContentType(params) {
 }
 
 function isContentTypeBinaryMimeType(params) {
-  return Boolean(params.binaryMimeTypes.length && isType.is(params.contentType, params.binaryMimeTypes));
+  return params.binaryMimeTypes.length > 0 && !!isType.is(params.contentType, params.binaryMimeTypes);
 }
 
 function mapApiGatewayEventToHttpRequest(event, context, socketPath) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4206,6 +4206,11 @@
         }
       }
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -6669,6 +6674,30 @@
       "dev": true,
       "requires": {
         "prelude-ls": "1.1.2"
+      }
+    },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.18"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "requires": {
+            "mime-db": "1.33.0"
+          }
+        }
       }
     },
     "typedarray": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "security-scan": "nsp check"
   },
   "dependencies": {
-    "binary-case": "^1.0.0"
+    "binary-case": "^1.0.0",
+    "type-is": "^1.6.16"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
This PR adds support for wildcards in the `binaryMimeTypes` parameter. This allows for more flexibility when defining which responses should be base64-encoded.