### PR TITLE
Add middleware name for a better log/stacktrace read

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,4 +1,4 @@
-module.exports.eventContext = options => (req, res, next) => {
+module.exports.eventContext = options => function apiGatewayEventParser (req, res, next) {
     options = options || {} // defaults: {reqPropKey: 'apiGateway', deleteHeaders: true}
     const reqPropKey = options.reqPropKey || 'apiGateway'
     const deleteHeaders = options.deleteHeaders === undefined ? true : options.deleteHeaders


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add middleware name for a better log/stacktrace read:
`Sat, 19 May 2018 08:14:49 GMT express:router use '/' <anonymous>`
becomes
`Sat, 19 May 2018 08:37:06 GMT express:router use '/' apiGatewayEventParser`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
