### PR TITLE
set Content-Length header in mapApiGatewayEventToHttpRequest

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -51,6 +51,8 @@ function mapApiGatewayEventToHttpRequest(headers) {
         headers
     }
     const eventClone = JSON.parse(JSON.stringify(event))
+    // NOTE: mapApiGatewayEventToHttpRequest will specify Content-Length if not specified
+    eventClone.headers = Object.assign(eventClone.headers || {}, {'Content-Length': Buffer.byteLength(eventClone.body)})
     delete eventClone.body
     const context = {
         'foo': 'bar'
@@ -68,6 +70,7 @@ test('mapApiGatewayEventToHttpRequest: with headers', () => {
         method: 'GET',
         path: '/foo',
         headers: {
+            'Content-Length': Buffer.byteLength('Hello serverless!'),
             'x-foo': 'foo',
             'x-apigateway-event': encodeURIComponent(JSON.stringify(r.eventClone)),
             'x-apigateway-context': encodeURIComponent(JSON.stringify(r.context))
@@ -83,6 +86,7 @@ test('mapApiGatewayEventToHttpRequest: without headers', () => {
         method: 'GET',
         path: '/foo',
         headers: {
+            'Content-Length': Buffer.byteLength('Hello serverless!'),
             'x-apigateway-event': encodeURIComponent(JSON.stringify(r.eventClone)),
             'x-apigateway-context': encodeURIComponent(JSON.stringify(r.context))
         },

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function forwardResponseToApiGateway(server, response, context) {
             const bodyBuffer = Buffer.concat(buf)
             const statusCode = response.statusCode
             const headers = response.headers
-            
+
             // chunked transfer not currently supported by API Gateway
             if (headers['transfer-encoding'] === 'chunked') delete headers['transfer-encoding']
 

--- a/index.js
+++ b/index.js
@@ -33,13 +33,16 @@ function isContentTypeBinaryMimeType(params) {
 
 function mapApiGatewayEventToHttpRequest(event, context, socketPath) {
     const headers = event.headers || {} // NOTE: Mutating event.headers; prefer deep clone of event.headers
+    // NOTE: API Gateway is not setting Content-Length header on any requests even when they have a body  
+    if (event.body && !headers['Content-Length']) {
+        // set header on event directly so x-apigateway-event is set correctly later
+        if (!event.headers) event.headers = {}
+        event.headers['Content-Length'] = Buffer.byteLength(event.body)
+        headers['Content-Length'] = Buffer.byteLength(event.body)
+    }
     const eventWithoutBody = Object.assign({}, event)
     delete eventWithoutBody.body
 
-    // NOTE: API Gateway is not setting Content-Length header on any requests even when they have a body  
-    if (event.body && !headers['Content-Length']) {
-      headers['Content-Length'] = Buffer.byteLength(event.body)
-    }
     headers['x-apigateway-event'] = encodeURIComponent(JSON.stringify(eventWithoutBody))
     headers['x-apigateway-context'] = encodeURIComponent(JSON.stringify(context))
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ function mapApiGatewayEventToHttpRequest(event, context, socketPath) {
     const headers = event.headers || {} // NOTE: Mutating event.headers; prefer deep clone of event.headers
     const eventWithoutBody = Object.assign({}, event)
     delete eventWithoutBody.body
-
+  
+    headers['Content-Length'] = Buffer.byteLength(event.body)
     headers['x-apigateway-event'] = encodeURIComponent(JSON.stringify(eventWithoutBody))
     headers['x-apigateway-context'] = encodeURIComponent(JSON.stringify(context))
 
@@ -60,7 +61,7 @@ function forwardResponseToApiGateway(server, response, context) {
             const bodyBuffer = Buffer.concat(buf)
             const statusCode = response.statusCode
             const headers = response.headers
-
+            
             // chunked transfer not currently supported by API Gateway
             if (headers['transfer-encoding'] === 'chunked') delete headers['transfer-encoding']
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ function mapApiGatewayEventToHttpRequest(event, context, socketPath) {
     const headers = event.headers || {} // NOTE: Mutating event.headers; prefer deep clone of event.headers
     const eventWithoutBody = Object.assign({}, event)
     delete eventWithoutBody.body
-  
+
+    // NOTE: API Gateway is not setting Content-Length header on any requests even when they have a body  
     if (event.body && !headers['Content-Length']) {
       headers['Content-Length'] = Buffer.byteLength(event.body)
     }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,9 @@ function mapApiGatewayEventToHttpRequest(event, context, socketPath) {
     const eventWithoutBody = Object.assign({}, event)
     delete eventWithoutBody.body
   
-    headers['Content-Length'] = Buffer.byteLength(event.body)
+    if (event.body && !headers['Content-Length']) {
+      headers['Content-Length'] = Buffer.byteLength(event.body)
+    }
     headers['x-apigateway-event'] = encodeURIComponent(JSON.stringify(eventWithoutBody))
     headers['x-apigateway-context'] = encodeURIComponent(JSON.stringify(context))
 


### PR DESCRIPTION
*Issue #, if available:*
#106 
*Description of changes:*
- without content-length specified, it seems the body of DELETE requests get ignored
- per RFC 2616, section 4.3:
  > The presence of a message-body in a request is signaled by the inclusion of a Content-Length or Transfer-Encoding header field in the request's message-headers. A message-body MUST NOT be included in a request if the specification of the request method (section 5.1.1) does not allow sending an entity-body in requests. A server SHOULD read and forward a message-body on any request; if the request method does not include defined semantics for an entity-body, then the message-body SHOULD be ignored when handling the request.
  - in other words, whether or not it is recommended to have a body in a DELETE request, if the content-length header (or the transfer-encoding header) is set, the message body should be forwarded
- concerns:
  - ~I'm not sure whether it is necessary to perform more type checking on `event.body`. for instance, if it is an object, it should be passed through a call to `JSON.stringify` before getting the byte length~ [not necessary](https://github.com/awslabs/aws-serverless-express/pull/147#issuecomment-398913288)
  - ~the header should probably be set only if not already specified~ 1ef34b8

I would love feedback on this 🙇 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
