### PR TITLE
add contentHandling CONVERT_TO_TEXT

### DIFF
--- a/example/simple-proxy-api.yaml
+++ b/example/simple-proxy-api.yaml
@@ -41,6 +41,7 @@ paths:
             Access-Control-Allow-Headers:
               type: string
       x-amazon-apigateway-integration:
+        contentHandling: CONVERT_TO_TEXT
         responses:
           default:
             statusCode: 200


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-serverless-express/issues/58

*Description of changes:*
contentHandling: CONVERT_TO_TEXT to enable CORS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
