### PR TITLE
test: fix getSocketPath test for Windows

### DIFF
--- a/__tests__/unit.js
+++ b/__tests__/unit.js
@@ -92,7 +92,13 @@ test('mapApiGatewayEventToHttpRequest: without headers', () => {
 
 test('getSocketPath', () => {
   const socketPath = awsServerlessExpress.getSocketPath('12345abcdef')
-  expect(socketPath).toEqual('/tmp/server-12345abcdef.sock')
+  var isWin = process.platform === 'win32'
+  if (isWin) {
+    const last = socketPath.split('\\').slice(-1)[0]
+    expect(last).toEqual('server-12345abcdef')
+  } else {
+    expect(socketPath).toEqual('/tmp/server-12345abcdef.sock')
+  }
 })
 
 const PassThrough = require('stream').PassThrough

--- a/__tests__/unit.js
+++ b/__tests__/unit.js
@@ -1,4 +1,7 @@
 'use strict'
+
+const path = require('path')
+
 const awsServerlessExpress = require('../src/index')
 
 test('getPathWithQueryStringParams: no params', () => {
@@ -92,13 +95,9 @@ test('mapApiGatewayEventToHttpRequest: without headers', () => {
 
 test('getSocketPath', () => {
   const socketPath = awsServerlessExpress.getSocketPath('12345abcdef')
-  var isWin = process.platform === 'win32'
-  if (isWin) {
-    const last = socketPath.split('\\').slice(-1)[0]
-    expect(last).toEqual('server-12345abcdef')
-  } else {
-    expect(socketPath).toEqual('/tmp/server-12345abcdef.sock')
-  }
+  const isWin = process.platform === 'win32'
+  const expectedSocketPath = isWin ? path.join('\\\\?\\\\pipe\\\\', process.cwd(), 'server-12345abcdef') : '/tmp/server-12345abcdef.sock'
+  expect(socketPath).toBe(expectedSocketPath)
 })
 
 const PassThrough = require('stream').PassThrough


### PR DESCRIPTION
Added if statement to see if we're running on Windows. If so, then the socket path will look like this:
`\\?\pipe\C:\repo\github\aws-serverless-express\server-12345abcdef`
rather than:
`/tmp/server-12345abcdef.sock`

so we just evaluate the last segment from the Windows path.