### PR TITLE
feat: add option of specifying resolveMode

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -50,6 +50,19 @@ function makeResponse (response) {
 }
 
 describe('integration tests', () => {
+  test('proxy returns server', (done) => {
+    const succeed = () => {
+      done()
+    }
+
+    const server = lambdaFunction.handler(makeEvent({
+      path: '/',
+      httpMethod: 'GET'
+    }), {
+      succeed
+    })
+    expect(server._socketPathSuffix).toBeTruthy()
+  })
   test('GET HTML (initial request)', (done) => {
     const succeed = response => {
       delete response.headers.date

--- a/__tests__/unit.js
+++ b/__tests__/unit.js
@@ -128,9 +128,7 @@ describe('forwardConnectionErrorResponseToApiGateway', () => {
       (resolve, reject) => {
         const context = new MockContext(resolve)
         const contextResolver = {
-          succeed: ({
-            response
-          }) => context.succeed(response)
+          succeed: (p) => context.succeed(p.response)
         }
         awsServerlessExpress.forwardConnectionErrorResponseToApiGateway('ERROR', contextResolver)
       }
@@ -148,9 +146,7 @@ describe('forwardLibraryErrorResponseToApiGateway', () => {
       (resolve, reject) => {
         const context = new MockContext(resolve)
         const contextResolver = {
-          succeed: ({
-            response
-          }) => context.succeed(response)
+          succeed: (p) => context.succeed(p.response)
         }
         awsServerlessExpress.forwardLibraryErrorResponseToApiGateway('ERROR', contextResolver)
       }
@@ -165,9 +161,7 @@ describe('forwardLibraryErrorResponseToApiGateway', () => {
 function getContextResolver (resolve) {
   const context = new MockContext(resolve)
   const contextResolver = {
-    succeed: ({
-      response
-    }) => context.succeed(response)
+    succeed: (p) => context.succeed(p.response)
   }
 
   return contextResolver

--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,7 @@ function createServer (requestListener, serverListenCallback, binaryTypes) {
   return server
 }
 
-function proxy (server, event, context, resolutionMode, callback = () => null) {
+function proxy (server, event, context, resolutionMode, callback) {
   // DEPRECATED: Legacy support
   if (!resolutionMode) {
     const resolver = makeResolver({ context, resolutionMode: 'CONTEXT_SUCCEED' })
@@ -218,19 +218,19 @@ function proxy (server, event, context, resolutionMode, callback = () => null) {
   }
 }
 
-function makeResolver ({
+function makeResolver (params/* {
   context,
   callback,
   promise,
   resolutionMode
-}) {
+} */) {
   return {
-    succeed: ({
+    succeed: (params2/* {
       response
-    }) => {
-      if (resolutionMode === 'CONTEXT_SUCCEED') return context.succeed(response)
-      if (resolutionMode === 'CALLBACK') return callback(null, response)
-      if (resolutionMode === 'PROMISE') return promise.resolve(response)
+    } */) => {
+      if (params.resolutionMode === 'CONTEXT_SUCCEED') return params.context.succeed(params2.response)
+      if (params.resolutionMode === 'CALLBACK') return params.callback(null, params2.response)
+      if (params.resolutionMode === 'PROMISE') return params.promise.resolve(params2.response)
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ function mapApiGatewayEventToHttpRequest (event, context, socketPath) {
   }
 }
 
-function forwardResponseToApiGateway (server, response, context) {
+function forwardResponseToApiGateway (server, response, resolver) {
   let buf = []
 
   response
@@ -88,11 +88,11 @@ function forwardResponseToApiGateway (server, response, context) {
       const body = bodyBuffer.toString(isBase64Encoded ? 'base64' : 'utf8')
       const successResponse = {statusCode, body, headers, isBase64Encoded}
 
-      context.succeed(successResponse)
+      resolver.succeed({ response: successResponse })
     })
 }
 
-function forwardConnectionErrorResponseToApiGateway (server, error, context) {
+function forwardConnectionErrorResponseToApiGateway (error, resolver) {
   console.log('ERROR: aws-serverless-express connection error')
   console.error(error)
   const errorResponse = {
@@ -101,10 +101,10 @@ function forwardConnectionErrorResponseToApiGateway (server, error, context) {
     headers: {}
   }
 
-  context.succeed(errorResponse)
+  resolver.succeed({ response: errorResponse })
 }
 
-function forwardLibraryErrorResponseToApiGateway (server, error, context) {
+function forwardLibraryErrorResponseToApiGateway (error, resolver) {
   console.log('ERROR: aws-serverless-express error')
   console.error(error)
   const errorResponse = {
@@ -113,13 +113,13 @@ function forwardLibraryErrorResponseToApiGateway (server, error, context) {
     headers: {}
   }
 
-  context.succeed(errorResponse)
+  resolver.succeed({ response: errorResponse })
 }
 
-function forwardRequestToNodeServer (server, event, context) {
+function forwardRequestToNodeServer (server, event, context, resolver) {
   try {
     const requestOptions = mapApiGatewayEventToHttpRequest(event, context, getSocketPath(server._socketPathSuffix))
-    const req = http.request(requestOptions, (response, body) => forwardResponseToApiGateway(server, response, context))
+    const req = http.request(requestOptions, (response) => forwardResponseToApiGateway(server, response, resolver))
     if (event.body) {
       if (event.isBase64Encoded) {
         event.body = Buffer.from(event.body, 'base64')
@@ -128,10 +128,10 @@ function forwardRequestToNodeServer (server, event, context) {
       req.write(event.body)
     }
 
-    req.on('error', (error) => forwardConnectionErrorResponseToApiGateway(server, error, context))
+    req.on('error', (error) => forwardConnectionErrorResponseToApiGateway(error, resolver))
       .end()
   } catch (error) {
-    forwardLibraryErrorResponseToApiGateway(server, error, context)
+    forwardLibraryErrorResponseToApiGateway(error, resolver)
     return server
   }
 }
@@ -182,13 +182,56 @@ function createServer (requestListener, serverListenCallback, binaryTypes) {
   return server
 }
 
-function proxy (server, event, context) {
-  if (server._isListening) {
-    forwardRequestToNodeServer(server, event, context)
-    return server
-  } else {
-    return startServer(server)
-      .on('listening', () => proxy(server, event, context))
+function proxy (server, event, context, resolutionMode, callback = () => null) {
+  // DEPRECATED: Legacy support
+  if (!resolutionMode) {
+    const resolver = makeResolver({ context, resolutionMode: 'CONTEXT_SUCCEED' })
+    if (server._isListening) {
+      forwardRequestToNodeServer(server, event, context, resolver)
+      return server
+    } else {
+      return startServer(server)
+        .on('listening', () => proxy(server, event, context))
+    }
+  }
+
+  return {
+    promise: new Promise((resolve, reject) => {
+      const promise = {
+        resolve,
+        reject
+      }
+      const resolver = makeResolver({
+        context,
+        callback,
+        promise,
+        resolutionMode
+      })
+
+      if (server._isListening) {
+        forwardRequestToNodeServer(server, event, context, resolver)
+      } else {
+        startServer(server)
+          .on('listening', () => forwardRequestToNodeServer(server, event, context, resolver))
+      }
+    })
+  }
+}
+
+function makeResolver ({
+  context,
+  callback,
+  promise,
+  resolutionMode
+}) {
+  return {
+    succeed: ({
+      response
+    }) => {
+      if (resolutionMode === 'CONTEXT_SUCCEED') return context.succeed(response)
+      if (resolutionMode === 'CALLBACK') return callback(null, response)
+      if (resolutionMode === 'PROMISE') return promise.resolve(response)
+    }
   }
 }
 
@@ -205,4 +248,5 @@ if (process.env.NODE_ENV === 'test') {
   exports.forwardRequestToNodeServer = forwardRequestToNodeServer
   exports.startServer = startServer
   exports.getSocketPath = getSocketPath
+  exports.makeResolver = makeResolver
 }


### PR DESCRIPTION
Allows resolving using Promise, callback, or the default context.succeed.

API decisions were made to support backwards compatibility. We will clean up the interface in a future major version bump

```js
exports.handler = async (event, context) => awsServerlessExpress.proxy(server, event, context, 'PROMISE')
```

Please ensure all pull requests are made against the `develop` branch.

*Issue #134, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
