### PR TITLE
Added an item in Cons

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ app.get('/', (req, res) => {
  - Cannot use native libraries (aka [Addons](https://nodejs.org/api/addons.html)) unless you package your app on an EC2 machine running Amazon Linux
  - Stateless only
  - API Gateway has a timeout of 30 seconds, and Lambda has a maximum execution time of 5 minutes.
+ - No control over infrastrucutre = can't use traditional application security solutions.


### PR DESCRIPTION
Can't use WAF (for cloud-native events) / RASP / EPP / WSG / NGFW.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
