### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ app.get('/', (req, res) => {
  - For apps that may not see traffic for several minutes at a time, you could see [cold starts](https://aws.amazon.com/blogs/compute/container-reuse-in-lambda/)
  - Cannot use native libraries (aka [Addons](https://nodejs.org/api/addons.html)) unless you package your app on an EC2 machine running Amazon Linux
  - Stateless only
- - API Gateway has a timeout of 30 seconds, and Lambda has a maximum execution time of 5 minutes.
+ - API Gateway has a timeout of 30 seconds, and Lambda has a maximum execution time of 15 minutes.


### PR DESCRIPTION
Please ensure all pull requests are made against the `develop` branch.

*Issue #, if available:*

*Description of changes:*
> You can now configure your AWS Lambda functions to run up to 15 minutes per execution. Previously, the maximum execution time (timeout) for a Lambda function was 5 minutes.

https://forums.aws.amazon.com/ann.jspa?annID=6198

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
