### PR TITLE
fix: add image/x-icon to MIME Type in order to fix error

### DIFF
--- a/examples/basic-starter/lambda.js
+++ b/examples/basic-starter/lambda.js
@@ -17,6 +17,7 @@ const binaryMimeTypes = [
   'image/jpeg',
   'image/png',
   'image/svg+xml',
+  'image/x-icon',
   'text/comma-separated-values',
   'text/css',
   'text/html',


### PR DESCRIPTION
Please ensure all pull requests are made against the `develop` branch.

*Issue #, if available:*
N/A

*Description of changes:*
Add image/x-icon to MIME Type in order to fix ‘favicon.ico net::ERR_CONTENT_DECODING_FAILED’ error. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
