### PR TITLE
Updated to use os.tmpdir() instead of hardcoded '/tmp'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 'use strict'
+const os = require('os')
 const http = require('http')
 const url = require('url')
 const binarycase = require('binary-case')
@@ -158,7 +159,8 @@ function getSocketPath (socketPathSuffix) {
     const path = require('path')
     return path.join('\\\\?\\pipe', process.cwd(), `server-${socketPathSuffix}`)
   } else {
-    return `/tmp/server-${socketPathSuffix}.sock`
+    const tmpDir = os.tmpdir()
+    return tmpDir + `/server-${socketPathSuffix}.sock`
   }
 }
 


### PR DESCRIPTION
When running locally the temp dir can vary by OS.

Please ensure all pull requests are made against the `develop` branch.

*Issue #, if available:* None

*Description of changes:*

The temp directory can vary based on OS. When runnning locally (e.g. using the serverless framework - `sls invoke local -f function`  if an OS or user does not use /tmp/ this code line fails. Updating to use the node.js OS module to get the tmp dir

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
