### PR TITLE
Support multi value query string parameters

### DIFF
--- a/__tests__/middleware.js
+++ b/__tests__/middleware.js
@@ -7,7 +7,7 @@ const generateMockReq = () => {
     headers: {
       'x-apigateway-event': encodeURIComponent(JSON.stringify({
         path: '/foo/bar',
-        queryStringParameters: {
+        multiValueQueryStringParameters: {
           foo: '🖖',
           bar: '~!@#$%^&*()_+`-=;\':",./<>?`'
         }

--- a/__tests__/unit.js
+++ b/__tests__/unit.js
@@ -15,7 +15,7 @@ test('getPathWithQueryStringParams: no params', () => {
 test('getPathWithQueryStringParams: 1 param', () => {
   const event = {
     path: '/foo/bar',
-    queryStringParameters: {
+    multiValueQueryStringParameters: {
       'bizz': 'bazz'
     }
   }
@@ -26,7 +26,7 @@ test('getPathWithQueryStringParams: 1 param', () => {
 test('getPathWithQueryStringParams: to be url-encoded param', () => {
   const event = {
     path: '/foo/bar',
-    queryStringParameters: {
+    multiValueQueryStringParameters: {
       'redirect_uri': 'http://lvh.me:3000/cb'
     }
   }
@@ -37,13 +37,27 @@ test('getPathWithQueryStringParams: to be url-encoded param', () => {
 test('getPathWithQueryStringParams: 2 params', () => {
   const event = {
     path: '/foo/bar',
-    queryStringParameters: {
+    multiValueQueryStringParameters: {
       'bizz': 'bazz',
       'buzz': 'bozz'
     }
   }
   const pathWithQueryStringParams = awsServerlessExpress.getPathWithQueryStringParams(event)
   expect(pathWithQueryStringParams).toEqual('/foo/bar?bizz=bazz&buzz=bozz')
+})
+
+test('getPathWithQueryStringParams: array param', () => {
+  const event = {
+    path: '/foo/bar',
+    multiValueQueryStringParameters: {
+      'bizz': [
+        'bazz',
+        'buzz'
+      ]
+    }
+  }
+  const pathWithQueryStringParams = awsServerlessExpress.getPathWithQueryStringParams(event)
+  expect(pathWithQueryStringParams).toEqual('/foo/bar?bizz=bazz&bizz=buzz')
 })
 
 function mapApiGatewayEventToHttpRequest (headers) {

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const binarycase = require('binary-case')
 const isType = require('type-is')
 
 function getPathWithQueryStringParams (event) {
-  return url.format({ pathname: event.path, query: event.queryStringParameters })
+  return url.format({ pathname: event.path, query: event.multiValueQueryStringParameters })
 }
 function getEventBody (event) {
   return Buffer.from(event.body, event.isBase64Encoded ? 'base64' : 'utf8')


### PR DESCRIPTION
Use `multiValueQueryStringParameters` instead of `queryStringParameters` from lambda event to build url.

[Amazon API Gateway Docs: Support for Multi-Value Headers and Query String Parameters](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#apigateway-multivalue-headers-and-parameters)