### PR TITLE
Accepting multiple values query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [3.3.6](https://github.com/awslabs/aws-serverless-express/compare/v3.3.5...v3.3.6) (2019-03-26)
+
+
+### Bug Fixes
+
+* remove commitlint from travis ([7b12e56](https://github.com/awslabs/aws-serverless-express/commit/7b12e56))
+* remove Node.js 4 support ([713ad14](https://github.com/awslabs/aws-serverless-express/commit/713ad14))
+* remove Node.js 4 support ([e01c9af](https://github.com/awslabs/aws-serverless-express/commit/e01c9af))
+* update dependencies ([075e15b](https://github.com/awslabs/aws-serverless-express/commit/075e15b))
+* update dependencies ([39c55eb](https://github.com/awslabs/aws-serverless-express/commit/39c55eb))
+
 <a name="3.3.5"></a>
 ## [3.3.5](https://github.com/awslabs/aws-serverless-express/compare/v3.3.4...v3.3.5) (2018-08-20)
 

--- a/__tests__/unit.js
+++ b/__tests__/unit.js
@@ -46,6 +46,21 @@ test('getPathWithQueryStringParams: 2 params', () => {
   expect(pathWithQueryStringParams).toEqual('/foo/bar?bizz=bazz&buzz=bozz')
 })
 
+test('getPathWithQueryStringParams: merging queryStringParameters with multiValueQueryStringParameters', () => {
+  const event = {
+    path: '/foo/bar',
+    queryStringParameters: {
+      'bizz': 'bazz',
+      'buzz': 'two'
+    },
+    multiValueQueryStringParameters: {
+      'buzz': ['one', 'two']
+    }
+  }
+  const pathWithQueryStringParams = awsServerlessExpress.getPathWithQueryStringParams(event)
+  expect(pathWithQueryStringParams).toEqual('/foo/bar?bizz=bazz&buzz=one&buzz=two')
+})
+
 function mapApiGatewayEventToHttpRequest (headers) {
   const event = {
     path: '/foo',

--- a/examples/basic-starter/api-gateway-event.json
+++ b/examples/basic-starter/api-gateway-event.json
@@ -4,6 +4,7 @@
     "path": "/users",
     "resource": "/{proxy+}",
     "queryStringParameters": {},
+    "multiValueQueryStringParameters": {},
     "pathParameters": {
         "proxy": "users"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-serverless-express",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-serverless-express",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "This library enables you to utilize AWS Lambda and Amazon API Gateway to respond to web and API requests using your existing Node.js application framework.",
   "keywords": [
     "aws",

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,9 @@ const binarycase = require('binary-case')
 const isType = require('type-is')
 
 function getPathWithQueryStringParams (event) {
-  return url.format({ pathname: event.path, query: event.queryStringParameters })
+  const query = Object.assign({}, event.queryStringParameters, event.multiValueQueryStringParameters)
+
+  return url.format({ pathname: event.path, query: query })
 }
 function getEventBody (event) {
   return Buffer.from(event.body, event.isBase64Encoded ? 'base64' : 'utf8')


### PR DESCRIPTION
Please ensure all pull requests are made against the `develop` branch.

*Description of changes:* When multiple values parameters on query string are sent to an api gateway then to a lambda, the event have the attribute `multiValueQueryStringParameters`.

Example:
QueryString: `test?foo=one&foo=two`, will generate the event:
```
const event = {
    path: '/foo/bar',
    queryStringParameters: {
      'foo': 'two'
    },
    multiValueQueryStringParameters: {
      'foo': ['one', 'two']
    }
  }
```

The proxy generates just send `?foo=two` to express, with my fix it send the correct query String `?foo=one&foo=two`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
