### PR TITLE
perf: using Object.assign for cloning the event object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,10 +25,6 @@ function getEventBody (event) {
   return Buffer.from(event.body, event.isBase64Encoded ? 'base64' : 'utf8')
 }
 
-function clone (json) {
-  return JSON.parse(JSON.stringify(json))
-}
-
 function getContentType (params) {
   // only compare mime type; ignore encoding part
   return params.contentTypeHeader ? params.contentTypeHeader.split(';')[0] : ''
@@ -47,8 +43,7 @@ function mapApiGatewayEventToHttpRequest (event, context, socketPath) {
     headers['Content-Length'] = Buffer.byteLength(body)
   }
 
-  const clonedEventWithoutBody = clone(event)
-  delete clonedEventWithoutBody.body
+  const clonedEventWithoutBody = Object.assign({}, event, { body: undefined })
 
   headers['x-apigateway-event'] = encodeURIComponent(JSON.stringify(clonedEventWithoutBody))
   headers['x-apigateway-context'] = encodeURIComponent(JSON.stringify(context))


### PR DESCRIPTION
*Description of changes:*

Use `Object.assign` to create a copy of the event object with an empty body. 

It's faster and uses less memory than the `JSON.parse(JSON.stringify())` approach. `Object.assign` creates a shallow copy, but it's not an issue in this particular use case.
