### PR TITLE
Add Promise return type for proxy function

### DIFF
--- a/src/proxy.d.ts
+++ b/src/proxy.d.ts
@@ -5,6 +5,6 @@ interface ProxyParams {
   binaryMimeTypes?: string[]
 }
 
-declare function proxy(proxyParams: ProxyParams): Promise
+declare function proxy(proxyParams: ProxyParams): Promise<any>
 
 export default ProxyParams


### PR DESCRIPTION
Compiling this project in TypeScript 4.1.2 gave the following error:
```
error TS2314: Generic type 'Promise<T>' requires 1 type argument(s).
declare function proxy(proxyParams: ProxyParams): Promise
```
This commit tries to fix this error without being explicit with the return type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.