### PR TITLE
Cookies must be set in the response json for api gateway v2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Please ensure all pull requests are made against the `develop` branch.
 
 # Checklist
 
-[ ] Tests have been added and are passing
-[ ] Documentation has been updated
+- [ ] Tests have been added and are passing
+- [ ] Documentation has been updated
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/examples/basic-starter-api-gateway-v2/package.json
+++ b/examples/basic-starter-api-gateway-v2/package.json
@@ -25,7 +25,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@vendia/serverless-express": "^4.0.0-rc.8",
+    "@vendia/serverless-express": "^4.0.0-rc.10",
     "body-parser": "^1.17.1",
     "compression": "^1.6.2",
     "cors": "^2.8.3",

--- a/src/event-sources/aws/api-gateway-v2.js
+++ b/src/event-sources/aws/api-gateway-v2.js
@@ -56,9 +56,13 @@ function getResponseToApiGateway ({
     throw new Error('chunked encoding is not supported by API Gateway')
   }
 
+  const cookies = headers["set-cookie"];
+  delete headers["set-cookie"];
+
   return {
     statusCode,
     body,
+    cookies,
     headers,
     isBase64Encoded
   }


### PR DESCRIPTION
Please ensure all pull requests are made against the `develop` branch.

*Issue #355:*

*Description of changes:*

Move `set-cookie` array outside of `headers` and put it in `cookies` array in the response json body.
this is required for api gateway v2

# Checklist

[ ] Tests have been added and are passing
[ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.