### PR TITLE
fix: make optional `ConfigureParams.binarySettings` in typings

### DIFF
--- a/src/configure.d.ts
+++ b/src/configure.d.ts
@@ -6,7 +6,7 @@ import ProxyParams from "./proxy"
 interface ConfigureParams {
   app: RequestListener,
   binaryMimeTypes?: string[],
-  binarySettings: BinarySettings
+  binarySettings?: BinarySettings
 }
 
 interface BinarySettings {


### PR DESCRIPTION
Please ensure all pull requests are made against the `develop` branch.

*Description of changes:*
The property `binarySettings` in `ConfigureParams` introduce in the rc11 was marked as required will it was optional. I just fixed the typings associated to the interface

# Checklist

- [x] Tests have been added and are passing
- [x] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
