### PR TITLE
fix: enhance accuracy of type definitions

### DIFF
--- a/src/configure.d.ts
+++ b/src/configure.d.ts
@@ -34,7 +34,7 @@ interface ConfigureResult {
   proxy: (proxyParams: ProxyParams) => Promise<Object>;
 }
 
-declare function configure(configureParams: ConfigureParams): ConfigureResult;
+declare function configure(configureParams: ConfigureParams): Handler & ConfigureResult;
 
 // declare function proxy(proxyParams: ProxyParams): Promise<any>
 

--- a/src/current-invoke.d.ts
+++ b/src/current-invoke.d.ts
@@ -1,0 +1,6 @@
+export interface CurrentInvoke {
+    event?: any;
+    context?: any;
+}
+
+export declare function getCurrentInvoke(): CurrentInvoke;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,5 @@
-import Configure from "./configure"
+import configure from "./configure"
 
-export = Configure
+export default configure;
+export { default as configure } from "./configure"
+export { getCurrentInvoke } from "./current-invoke"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated type definitions of main package exports to more closely align with what is actually exported and allow common examples to work for consumers using TypeScript.

Examples that used to fail:
```typescript
import { getCurrentInvoke } from '@vendia/serverless-express';
```

Simplified example from https://github.com/vendia/serverless-express/blob/mainline/examples/basic-starter-nestjs/src/lambda.ts
```typescript
import serverlessExpress from '@vendia/serverless-express';
import express from 'express';

exports.handler = (event, context, callback) => {
    const handler = serverlessExpress( { app: express() } );
    return handler(event, context, callback);
};
```

# Checklist

- [ ] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
