### PR TITLE
fix: make headers an object instead of an array

### DIFF
--- a/__tests__/unit.api-gateway-v2.js
+++ b/__tests__/unit.api-gateway-v2.js
@@ -1,0 +1,21 @@
+const eventSources = require('../src/event-sources')
+const testUtils = require('../src/event-sources/utils.test')
+
+const apiGatewayEventSource = eventSources.getEventSource({
+  eventSourceName: 'AWS_API_GATEWAY_V2'
+})
+
+test('request has correct headers', () => {
+  const req = getReq()
+  // see https://github.com/vendia/serverless-express/issues/387
+  expect(typeof req).toEqual('object')
+  expect(JSON.stringify(req.headers)).toEqual(
+    '{"cookie":"","host":"localhost:9000","user-agent":"curl/7.64.1","accept":"*/*","x-forwarded-proto":"http","x-forwarded-port":"9000"}'
+  )
+})
+
+function getReq () {
+  const event = testUtils.sam_httpapi_event
+  const request = apiGatewayEventSource.getRequest({ event })
+  return request
+}

--- a/src/event-sources/aws/api-gateway-v2.js
+++ b/src/event-sources/aws/api-gateway-v2.js
@@ -18,7 +18,7 @@ function getRequestValuesFromApiGatewayEvent ({ event }) {
     search: rawQueryString
   })
 
-  const headers = []
+  const headers = {}
 
   if (cookies) {
     headers.cookie = cookies.join('; ')

--- a/src/event-sources/utils.test.ts
+++ b/src/event-sources/utils.test.ts
@@ -50,3 +50,7 @@ describe("getEventSourceNameBasedOnEvent", () => {
     expect(result).toEqual("AWS_API_GATEWAY_V2");
   });
 });
+
+module.exports = {
+  sam_httpapi_event,
+};


### PR DESCRIPTION
*Description of changes:*

Currently, the generated headers look like this: 
```
[
'accept-encoding': 'gzip, deflate',
'content-length': 104,
'content-type': 'application/json',
'x-forwarded-port': '443',
'x-forwarded-proto': 'https'
]
```
The headers in `src/event-sources/aws/api-gateway-v2.js` are of type array but should be of type object. 

TIL: something like `headers['x-forwarded-proto']` still returns `https`. But: `JSON.stringify(headers)` returns an empty array.

# Checklist

- [x] Tests have been added and are passing -> added one, but not sure about the structure
- [ ] Documentation has been updated -> Not sure if this needs documentation?

If you think that tests and docs should be added, please let me know.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
