### PR TITLE
fix: fix aws api gateway v2 event source cookies handling

### DIFF
--- a/jest-helpers/api-gateway-v2-event.js
+++ b/jest-helpers/api-gateway-v2-event.js
@@ -102,6 +102,7 @@ function makeApiGatewayV2Response (values = {}, {
   }
   values.headers = convertMultiValueHeadersToHeaders({ multiValueHeaders: values.multiValueHeaders })
   delete values.multiValueHeaders
+  delete values.headers['set-cookie']
 
   if (shouldConvertContentLengthToInt) {
     // APIGWV2 returns content-length as a number instead of a string under certain conditions:

--- a/src/event-sources/aws/api-gateway-v2.js
+++ b/src/event-sources/aws/api-gateway-v2.js
@@ -63,7 +63,8 @@ function getResponseToApiGateway ({
   }
 
   if (headers['set-cookie']) {
-    responseToApiGateway.cookies = headers['set-cookie']
+    responseToApiGateway.cookies = Array.isArray(headers['set-cookie']) ? headers['set-cookie'] : [headers['set-cookie']]
+    delete headers['set-cookie']
   }
 
   responseToApiGateway.headers = getCommaDelimitedHeaders({ headersMap: headers })

--- a/src/event-sources/aws/api-gateway-v2.js
+++ b/src/event-sources/aws/api-gateway-v2.js
@@ -62,8 +62,9 @@ function getResponseToApiGateway ({
     isBase64Encoded
   }
 
-  if (headers['set-cookie']) {
-    responseToApiGateway.cookies = Array.isArray(headers['set-cookie']) ? headers['set-cookie'] : [headers['set-cookie']]
+  const cookies = headers['set-cookie']
+  if (cookies) {
+    responseToApiGateway.cookies = Array.isArray(cookies) ? cookies : [cookies]
     delete headers['set-cookie']
   }
 


### PR DESCRIPTION
*Issue #, if available:*
Issue #388

*Description of changes:*
**Change AWS API Gateway v2 event source**
- Insert Array check logic of 'set-cookie' headers
- Delete headers['set-cookie']

# Checklist

- [x] Tests have been added and are passing -> where should i insert test logic for api gateway v2 event source ?
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
