### PR TITLE
fix: auto-unescape query parameters on ALB (#219, #241)

### DIFF
--- a/src/event-sources/aws/alb.js
+++ b/src/event-sources/aws/alb.js
@@ -1,6 +1,42 @@
+const url = require('url')
 const { getRequestValuesFromEvent, getMultiValueHeaders } = require('../utils')
 
-const getRequestValuesFromAlbEvent = ({ event }) => getRequestValuesFromEvent({ event })
+function getPathWithQueryStringUseUnescapeParams ({
+  event,
+  // NOTE: Use `event.pathParameters.proxy` if available ({proxy+}); fall back to `event.path`
+  path = (event.pathParameters && event.pathParameters.proxy && `/${event.pathParameters.proxy}`) || event.path,
+  // NOTE: Strip base path for custom domains
+  stripBasePath = '',
+  replaceRegex = new RegExp(`^${stripBasePath}`)
+}) {
+  const query = {}
+  // decode everything back into utf-8 text.
+  if (event.multiValueQueryStringParameters) {
+    for (const key in event.multiValueQueryStringParameters) {
+      const formattedKey = decodeURIComponent(key)
+      query[formattedKey] = event.multiValueQueryStringParameters[key].map(value => decodeURIComponent(value))
+    }
+  } else {
+    for (const key in event.queryStringParameters) {
+      const formattedKey = decodeURIComponent(key)
+      query[formattedKey] = decodeURIComponent(event.queryStringParameters[key])
+    }
+  }
+
+  return url.format({
+    pathname: path.replace(replaceRegex, ''),
+    query
+  })
+}
+
+const getRequestValuesFromAlbEvent = ({ event }) => {
+  const values = getRequestValuesFromEvent({
+    event,
+    path: getPathWithQueryStringUseUnescapeParams({ event })
+  })
+  return values
+}
+
 const getResponseToAlb = ({
   statusCode,
   body,


### PR DESCRIPTION
*Issue #, if available:*
#219, #241

*Description of changes:*
This will auto-unescape query parameters in ALB. And avoid the hacks found in https://github.com/vendia/serverless-express/issues/219
#241 was closed, because of ALB support in v4 maybe? But the unescape part was important in the ticket, but I couldn't see anything like that on the main branch.
It could be a breaking change for people who already handle this case. It's maybe better integrated on a mayor version.
It was made with the assumption that Api gateway ports already auto-unescape these parameters. But I'm not sure of that.
Some of the changes could be better made in `src/event-sources/utils.js` anyway. 

# Checklist

- [ ] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
