### PR TITLE
types: update configure.d.ts

### DIFF
--- a/src/configure.d.ts
+++ b/src/configure.d.ts
@@ -28,13 +28,13 @@ interface BinarySettings {
   contentTypes?: string[];
 }
 
-interface ConfigureResult {
-  handler: Handler;
+interface ConfigureResult<TEvent = any, TResult = any> {
+  handler: Handler<TEvent, TResult>;
   log: Logger;
   proxy: (proxyParams: ProxyParams) => Promise<Object>;
 }
 
-declare function configure(configureParams: ConfigureParams): Handler & ConfigureResult;
+declare function configure<TEvent = any, TResult = any>(configureParams: ConfigureParams): Handler<TEvent, TResult> & ConfigureResult<TEvent, TResult>;
 
 // declare function proxy(proxyParams: ProxyParams): Promise<any>
 


### PR DESCRIPTION
This allows the incoming payload and returns to be properly typed, it was using `any` by default without it (if the user doesn't specify it will still be `any` as I added a default to the generics).