### PR TITLE
fix: When custom resources are created on api gateway and mapped with…

### DIFF
--- a/src/event-sources/utils.js
+++ b/src/event-sources/utils.js
@@ -3,8 +3,12 @@ const url = require('url')
 function getPathWithQueryStringParams ({
   event,
   query = event.multiValueQueryStringParameters,
-  // NOTE: Use `event.pathParameters.proxy` if available ({proxy+}); fall back to `event.path`
-  path = (event.pathParameters && event.pathParameters.proxy && `/${event.pathParameters.proxy}`) || event.path,
+  // NOTE: Always use event.path, if the API gateway has custom route setup, for example if my controllers path is
+  // something like employee/services/service1, employee/services/service2 etc, if I dont have any custom path/resources  setup
+  // and directly have root/{proxy+} it works as expected, if i have a resource like /employee and child to that if there
+  // is a resource like {proxy+} it is not working as expected and errors out with 404. This change is required to address that
+  // specific issue.
+  path = event.path,
   // NOTE: Strip base path for custom domains
   stripBasePath = '',
   replaceRegex = new RegExp(`^${stripBasePath}`)


### PR DESCRIPTION
… the NestJS proxy, it was not working as expected. The fix is made to address that issue


*Issue #, if available:*  if the API gateway has custom resource/route setup, for example if my controllers path is something like employee/services/service1, employee/services/service2 etc, if I don't have any custom path/resources  setup in the API gateway and directly have root/{proxy+} it works as expected, if i have a resource like /employee and child to that if there
 is a resource like {proxy+} it is not working as expected and errors out with 404. This change is required to address that specific issue.


*Description of changes:* Always use the path that is passed on in the event argument.

# Checklist

- [ ] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
