### PR TITLE
Revert the major breaking change in 4.3.10

### DIFF
--- a/src/event-sources/utils.js
+++ b/src/event-sources/utils.js
@@ -3,12 +3,8 @@ const url = require('url')
 function getPathWithQueryStringParams ({
   event,
   query = event.multiValueQueryStringParameters,
-  // NOTE: Always use event.path, if the API gateway has custom route setup, for example if my controllers path is
-  // something like employee/services/service1, employee/services/service2 etc, if I dont have any custom path/resources  setup
-  // and directly have root/{proxy+} it works as expected, if i have a resource like /employee and child to that if there
-  // is a resource like {proxy+} it is not working as expected and errors out with 404. This change is required to address that
-  // specific issue.
-  path = event.path,
+  // NOTE: Use `event.pathParameters.proxy` if available ({proxy+}); fall back to `event.path`
+  path = (event.pathParameters && event.pathParameters.proxy && `/${event.pathParameters.proxy}`) || event.path,
   // NOTE: Strip base path for custom domains
   stripBasePath = '',
   replaceRegex = new RegExp(`^${stripBasePath}`)


### PR DESCRIPTION
*Description of changes:*
Revert to the old behavior of just routing on the proxy part.

4.3.10 is a major breaking change for existing users depending on the current behavior.

* Issue #454

@selvendranayyaswamy
@selvendran.ayyaswamy

# Checklist

- [x] Tests have been added and are passing
- [x] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
