### PR TITLE
feat: export event sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   },
   "scripts": {
     "test": "jest && npm run tsc",
-    "tsc": "tsc ./src/*.ts --outDir typescript-out",
+    "tsc": "tsc ./src/**/*.ts --outDir typescript-out",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "cz": "git-cz",

--- a/src/event-sources/aws/alb.d.ts
+++ b/src/event-sources/aws/alb.d.ts
@@ -1,0 +1,23 @@
+declare function getRequestValuesFromAlbEvent({ event }: {
+  event: any;
+}): {
+  method: any;
+  headers: {
+      'content-length': number;
+  };
+  body: Buffer;
+  remoteAddress: any;
+  path: string;
+};
+declare function getResponseToAlb({ statusCode, body, headers, isBase64Encoded }: {
+  statusCode: any;
+  body: any;
+  headers: any;
+  isBase64Encoded: any;
+}): {
+  statusCode: any;
+  body: any;
+  multiValueHeaders: {};
+  isBase64Encoded: any;
+};
+export { getRequestValuesFromAlbEvent as getRequest, getResponseToAlb as getResponse };

--- a/src/event-sources/aws/api-gateway-v1.d.ts
+++ b/src/event-sources/aws/api-gateway-v1.d.ts
@@ -1,0 +1,23 @@
+declare function getRequestValuesFromApiGatewayEvent({ event }: {
+  event: any;
+}): {
+  method: any;
+  headers: {
+      'content-length': number;
+  };
+  body: Buffer;
+  remoteAddress: any;
+  path: string;
+};
+declare function getResponseToApiGateway({ statusCode, body, headers, isBase64Encoded }: {
+  statusCode: any;
+  body: any;
+  headers: any;
+  isBase64Encoded: any;
+}): {
+  statusCode: any;
+  body: any;
+  multiValueHeaders: {};
+  isBase64Encoded: any;
+};
+export { getRequestValuesFromApiGatewayEvent as getRequest, getResponseToApiGateway as getResponse };

--- a/src/event-sources/aws/api-gateway-v2.d.ts
+++ b/src/event-sources/aws/api-gateway-v2.d.ts
@@ -1,0 +1,24 @@
+declare function getRequestValuesFromApiGatewayEvent({ event }: {
+  event: any;
+}): {
+  method: any;
+  headers: {
+      cookie: any;
+      'content-length': number;
+  };
+  body: Buffer;
+  remoteAddress: any;
+  path: string;
+};
+declare function getResponseToApiGateway({ statusCode, body, headers, isBase64Encoded, response }: {
+  statusCode: any;
+  body: any;
+  headers?: {};
+  isBase64Encoded?: boolean;
+  response?: {};
+}): {
+  statusCode: any;
+  body: any;
+  isBase64Encoded: boolean;
+};
+export { getRequestValuesFromApiGatewayEvent as getRequest, getResponseToApiGateway as getResponse };

--- a/src/event-sources/aws/lambda-edge.d.ts
+++ b/src/event-sources/aws/lambda-edge.d.ts
@@ -1,0 +1,25 @@
+declare function getRequestValuesFromLambdaEdgeEvent({ event }: {
+  event: any;
+}): {
+  method: any;
+  path: string;
+  headers: {
+      'content-length': number;
+  };
+  body: Buffer;
+  remoteAddress: any;
+  host: any;
+  hostname: any;
+};
+declare function getResponseToLambdaEdge({ statusCode, body, headers, isBase64Encoded }: {
+  statusCode: any;
+  body: any;
+  headers: any;
+  isBase64Encoded: any;
+}): {
+  status: any;
+  body: any;
+  headers: {};
+  bodyEncoding: string;
+};
+export { getRequestValuesFromLambdaEdgeEvent as getRequest, getResponseToLambdaEdge as getResponse };

--- a/src/event-sources/index.d.ts
+++ b/src/event-sources/index.d.ts
@@ -1,0 +1,80 @@
+export function getEventSource({ eventSourceName }: {
+  eventSourceName: any;
+}): {
+  getRequest: ({ event }: {
+      event: any;
+  }) => {
+      method: any;
+      headers: {
+          'content-length': number;
+      };
+      body: Buffer;
+      remoteAddress: any;
+      path: string;
+  };
+  getResponse: ({ statusCode, body, headers, isBase64Encoded }: {
+      statusCode: any;
+      body: any;
+      headers: any;
+      isBase64Encoded: any;
+  }) => {
+      statusCode: any;
+      body: any;
+      multiValueHeaders: {};
+      isBase64Encoded: any;
+  };
+} | {
+  getRequest: ({ event }: {
+      event: any;
+  }) => {
+      method: any;
+      headers: {
+          cookie: any;
+          'content-length': number;
+      };
+      body: Buffer;
+      remoteAddress: any;
+      path: string;
+  };
+  getResponse: ({ statusCode, body, headers, isBase64Encoded, response }: {
+      statusCode: any;
+      body: any;
+      headers?: {};
+      isBase64Encoded?: boolean;
+      response?: {};
+  }) => {
+      statusCode: any;
+      body: any;
+      isBase64Encoded: boolean;
+  };
+} | {
+  getRequest: ({ event }: {
+      event: any;
+  }) => {
+      method: any;
+      path: string;
+      headers: {
+          'content-length': number;
+      };
+      body: Buffer;
+      remoteAddress: any;
+      host: any;
+      hostname: any;
+  };
+  getResponse: ({ statusCode, body, headers, isBase64Encoded }: {
+      statusCode: any;
+      body: any;
+      headers: any;
+      isBase64Encoded: any;
+  }) => {
+      status: any;
+      body: any;
+      headers: {};
+      bodyEncoding: string;
+  };
+};
+import awsApiGatewayV1EventSource = require("./aws/api-gateway-v1");
+import awsApiGatewayV2EventSource = require("./aws/api-gateway-v2");
+import awsAlbEventSource = require("./aws/alb");
+import awsLambdaEdgeEventSource = require("./aws/lambda-edge");
+export { awsApiGatewayV1EventSource, awsApiGatewayV2EventSource, awsAlbEventSource, awsLambdaEdgeEventSource };

--- a/src/event-sources/index.js
+++ b/src/event-sources/index.js
@@ -19,5 +19,9 @@ function getEventSource ({ eventSourceName }) {
 }
 
 module.exports = {
-  getEventSource
+  getEventSource,
+  awsApiGatewayV1EventSource,
+  awsApiGatewayV2EventSource,
+  awsAlbEventSource,
+  awsLambdaEdgeEventSource
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,3 +3,10 @@ import configure from "./configure"
 export default configure;
 export { default as configure } from "./configure"
 export { getCurrentInvoke } from "./current-invoke"
+export {
+  getEventSource,
+  awsAlbEventSource,
+  awsApiGatewayV1EventSource,
+  awsApiGatewayV2EventSource,
+  awsLambdaEdgeEventSource
+} from './event-sources'

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,21 @@
 const configure = require('./configure')
 const { getCurrentInvoke } = require('./current-invoke')
+const {
+  getEventSource,
+  awsAlbEventSource,
+  awsApiGatewayV1EventSource,
+  awsApiGatewayV2EventSource,
+  awsLambdaEdgeEventSource
+} = require('./event-sources')
 
 module.exports = configure
 module.exports.getCurrentInvoke = getCurrentInvoke
 module.exports.configure = configure
+module.exports.getEventSource = getEventSource
+module.exports.awsAlbEventSource = awsAlbEventSource
+module.exports.awsApiGatewayV1EventSource = awsApiGatewayV1EventSource
+module.exports.awsApiGatewayV2EventSource = awsApiGatewayV2EventSource
+module.exports.awsLambdaEdgeEventSource = awsLambdaEdgeEventSource
 
 // Legacy/deprecated:
 


### PR DESCRIPTION
*Description of changes:*

I'm attempting to make a single lambda function handle multiple events, but I need the various event sources exported.

This change exports them and adds the typescript declarations as well.

Let me know if there's a documentation change you'd like me to provide with this.

# Checklist

- [x] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
