### PR TITLE
fix: bug when empty event headers (#462)

### DIFF
--- a/src/event-sources/utils.js
+++ b/src/event-sources/utils.js
@@ -32,7 +32,7 @@ function getRequestValuesFromEvent ({
 
   if (event.multiValueHeaders) {
     headers = getCommaDelimitedHeaders({ headersMap: event.multiValueHeaders, lowerCaseKey: true })
-  } else {
+  } else if (event.headers) {
     headers = event.headers
   }
 


### PR DESCRIPTION
Due to in several express.js libraries treats req.headers as NonNullable Object,
when event headers is null causing bugs.

When incoming headers from API Gateway is null, it should transform to {}.

Fix #462, #417

*Issue #, if available:* #462, #417

*Description of changes:* check `event.headers` is null

# Checklist

- [ ] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
