### PR TITLE
fix: ensure response header value is string type

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -168,7 +168,7 @@ describe.each(EACH_MATRIX)('%s:%s: integration tests', (eventSourceName, framewo
     const expectedResponse = makeResponse({
       eventSourceName,
       multiValueHeaders: {
-        'content-length': [151],
+        'content-length': ['151'],
         'content-security-policy': ["default-src 'none'"],
         'content-type': ['text/html; charset=utf-8'],
         'x-content-type-options': ['nosniff']
@@ -223,7 +223,7 @@ describe.each(EACH_MATRIX)('%s:%s: integration tests', (eventSourceName, framewo
       multiValueHeaders: {
         'accept-ranges': ['bytes'],
         'cache-control': ['public, max-age=0'],
-        'content-length': [15933],
+        'content-length': ['15933'],
         'content-type': ['image/png']
       },
       isBase64Encoded: true

--- a/src/event-sources/utils.js
+++ b/src/event-sources/utils.js
@@ -59,7 +59,7 @@ function getMultiValueHeaders ({ headers }) {
   const multiValueHeaders = {}
 
   Object.entries(headers).forEach(([headerKey, headerValue]) => {
-    const headerArray = Array.isArray(headerValue) ? headerValue : [headerValue]
+    const headerArray = Array.isArray(headerValue) ? headerValue.map(String) : [String(headerValue)]
 
     multiValueHeaders[headerKey.toLowerCase()] = headerArray
   })


### PR DESCRIPTION
multiValueHeaders and headers maps while processing the integration response
into a single `Map<String, List>` value
https://kevinhakanson.com/2019-10-25-aws-alb-lambda-function-targets-and-multi-value-headers
https://javadoc.io/static/com.amazonaws/aws-lambda-java-events/2.2.7/com/amazonaws[…]services/lambda/runtime/events/APIGatewayProxyRequestEvent.html
`getMultiValueHeaders()` return as Map<String,List<String>>

currently there are some header value are not string type (e.g `content-length`), which will cause **502 error** on awselb/api gateway layer.

so we need to transform all headers value as string

# Checklist

- [x] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
