### PR TITLE
fix(http-function-runtime-v3): fix undeclared variable

### DIFF
--- a/src/event-sources/azure/http-function-runtime-v3.js
+++ b/src/event-sources/azure/http-function-runtime-v3.js
@@ -64,7 +64,7 @@ function getResponseToHttpFunction ({ statusCode, body, headers = {}, isBase64En
       }
 
       if (parsedCookie['max-age']) {
-        cookie.maxAge = parsedCookie['max-age']
+        cookie.maxAge = +parsedCookie['max-age']
       }
 
       if (parsedCookie.samesite) {
@@ -73,7 +73,7 @@ function getResponseToHttpFunction ({ statusCode, body, headers = {}, isBase64En
 
       if (parsedCookie.expires && typeof parsedCookie.expires === 'string') {
         cookie.expires = new Date(parsedCookie.expires)
-      } else if (parsedCookie.expires && typeof value === 'number') {
+      } else if (parsedCookie.expires && typeof parsedCookie.expires === 'number') {
         cookie.expires = parsedCookie.expires
       }
 


### PR DESCRIPTION
*Description of changes:*

I added support for Azure Functions in my library based on #484 and I notice this line:

https://github.com/vendia/serverless-express/blob/8cbeb30bbc92e2973cbd8780eb0fe6a826782d48/src/event-sources/azure/http-function-runtime-v3.js#L76

This `value` variable seems undeclared (I don't know how this thing didn't throw an error).

And I force the type of `max-age` to be number accords [maxAge in @azure/functions](https://github.com/Azure/azure-functions-nodejs-worker/blob/v3.x/types/index.d.ts#L405)

I also improve the test by adding validation for maxAge and expires.

# Checklist

- [x] Tests have been added and are passing
- [x] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
