### PR TITLE
feat(response): added support to Uint8Array

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -9,7 +9,6 @@ const {
   makeResponse,
   EACH_MATRIX
 } = require('../jest-helpers')
-
 const jestHelpersPath = path.join(__dirname, '..', 'jest-helpers')
 
 let app, router, serverlessExpressInstance

--- a/src/response.js
+++ b/src/response.js
@@ -12,13 +12,15 @@ function getString (data) {
     return data.toString('utf8')
   } else if (typeof data === 'string') {
     return data
+  } else if (data instanceof Uint8Array) {
+    return new TextDecoder().decode(data)
   } else {
     throw new Error(`response.write() of unexpected type: ${typeof data}`)
   }
 }
 
 function addData (stream, data) {
-  if (Buffer.isBuffer(data) || typeof data === 'string') {
+  if (Buffer.isBuffer(data) || typeof data === 'string' || data instanceof Uint8Array) {
     stream[BODY].push(Buffer.from(data))
   } else {
     throw new Error(`response.write() of unexpected type: ${typeof data}`)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/vendia/serverless-express/issues/539

*Description of changes:*

Added support for checking if the data is Uint8Array because Next.js returns it in ssr.

# About implementation

@brett-vendia I tried to add test to this new feature but I couldn't find anywhere to put it or how to test properly,
I added a test, but in the coverage I didn't see the new validation being marked as tested, any thoughts?

I also added support inside the `getString` function, in this https://github.com/dougmoscrop/serverless-http/pull/232 the author didn't add it, but to me it makes sense that the function also has support for Uint8Array.

# Checklist

- [x] Tests have been added and are passing
- [x] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
