### PR TITLE
fix: make sure to strip also base path non pathParameter

### DIFF
--- a/__tests__/unit.js
+++ b/__tests__/unit.js
@@ -10,6 +10,7 @@ const apiGatewayEventSource = eventSources.getEventSource({ eventSourceName: 'AW
 
 test('getPathWithQueryStringParams: no params', () => {
   const event = {
+    resource: '/',
     path: '/foo/bar'
   }
   const pathWithQueryStringParams = serverlessExpressEventSourcesUtils.getPathWithQueryStringParams({ event })
@@ -18,6 +19,7 @@ test('getPathWithQueryStringParams: no params', () => {
 
 test('getPathWithQueryStringParams: 1 param', () => {
   const event = {
+    resource: '/',
     path: '/foo/bar',
     multiValueQueryStringParameters: {
       bizz: 'bazz'
@@ -29,6 +31,7 @@ test('getPathWithQueryStringParams: 1 param', () => {
 
 test('getPathWithQueryStringParams: to be url-encoded param', () => {
   const event = {
+    resource: '/',
     path: '/foo/bar',
     multiValueQueryStringParameters: {
       redirect_uri: 'http://lvh.me:3000/cb'
@@ -40,6 +43,7 @@ test('getPathWithQueryStringParams: to be url-encoded param', () => {
 
 test('getPathWithQueryStringParams: 2 params', () => {
   const event = {
+    resource: '/',
     path: '/foo/bar',
     multiValueQueryStringParameters: {
       bizz: 'bazz',
@@ -52,6 +56,7 @@ test('getPathWithQueryStringParams: 2 params', () => {
 
 test('getPathWithQueryStringParams: array param', () => {
   const event = {
+    resource: '/',
     path: '/foo/bar',
     multiValueQueryStringParameters: {
       bizz: [
@@ -64,8 +69,52 @@ test('getPathWithQueryStringParams: array param', () => {
   expect(pathWithQueryStringParams).toEqual('/foo/bar?bizz=bazz&bizz=buzz')
 })
 
+test('getPathWithQueryStringParams: pathParameters.proxy', () => {
+  const event = {
+    resource: '/foo/{proxy+}',
+    path: '/foo/123',
+    pathParameters: {
+      proxy: '123'
+    }
+  }
+  const pathWithQueryStringParams = serverlessExpressEventSourcesUtils.getPathWithQueryStringParams({ event })
+  expect(pathWithQueryStringParams).toEqual('/123')
+})
+
+test('getPathWithQueryStringParams: customDomain and no path parameters', () => {
+  const event = {
+    resource: '/foo',
+    path: '/baz/foo',
+    requestContext: {
+      customDomain: {
+        basePathMatched: 'baz'
+      }
+    }
+  }
+  const pathWithQueryStringParams = serverlessExpressEventSourcesUtils.getPathWithQueryStringParams({ event })
+  expect(pathWithQueryStringParams).toEqual('/')
+})
+
+test('getPathWithQueryStringParams: customDomain and path parameters', () => {
+  const event = {
+    resource: '/foo/{proxy+}',
+    path: '/baz/foo/123',
+    pathParameters: {
+      proxy: '123'
+    },
+    requestContext: {
+      customDomain: {
+        basePathMatched: 'baz'
+      }
+    }
+  }
+  const pathWithQueryStringParams = serverlessExpressEventSourcesUtils.getPathWithQueryStringParams({ event })
+  expect(pathWithQueryStringParams).toEqual('/123')
+})
+
 function getReqRes (multiValueHeaders = {}) {
   const event = {
+    resource: '/',
     path: '/foo',
     httpMethod: 'GET',
     body: 'Hello serverless!',

--- a/src/event-sources/utils.js
+++ b/src/event-sources/utils.js
@@ -1,8 +1,8 @@
 const url = require('url')
 
 function getDefalutStripBasePath (event) {
-  const basePathMatched = (event.requestContext && event.requestContext.customDomain && event.requestContext.customDomain.basePathMatched) || ''
-  const resource = event.pathParameters && event.pathParameters.proxy ? '' : event.resource
+  const basePathMatched = event?.requestContext?.customDomain?.basePathMatched || ''
+  const resource = event?.pathParameters?.proxy ? '' : event.resource
   return basePathMatched ? `/${basePathMatched}${resource}` : resource
 }
 

--- a/src/event-sources/utils.js
+++ b/src/event-sources/utils.js
@@ -1,16 +1,23 @@
 const url = require('url')
 
+function getDefalutStripBasePath (event) {
+  const basePathMatched = (event.requestContext && event.requestContext.customDomain && event.requestContext.customDomain.basePathMatched) || ''
+  const resource = event.pathParameters && event.pathParameters.proxy ? '' : event.resource
+  return basePathMatched ? `/${basePathMatched}${resource}` : resource
+}
+
 function getPathWithQueryStringParams ({
   event,
   query = event.multiValueQueryStringParameters,
   // NOTE: Use `event.pathParameters.proxy` if available ({proxy+}); fall back to `event.path`
   path = (event.pathParameters && event.pathParameters.proxy && `/${event.pathParameters.proxy}`) || event.path,
   // NOTE: Strip base path for custom domains
-  stripBasePath = '',
+  stripBasePath = getDefalutStripBasePath(event),
   replaceRegex = new RegExp(`^${stripBasePath}`)
 }) {
+  const pathname = path.replace(replaceRegex, '')
   return url.format({
-    pathname: path.replace(replaceRegex, ''),
+    pathname: pathname.startsWith('/') ? pathname : `/${pathname}`,
     query
   })
 }


### PR DESCRIPTION
*Issue #, if available:*

fix #377

*Description of changes:*

When define resource `/users/${proxy+}`,  request to `/users/123` is path as `/123`. But when mapping `/users`,  request to `/users` is path as `/users` not `/`.  It is not symmetry.

BREAKING CHANGE: A handler of defined resource not use pathParameter be also less able to get base path.

# Checklist

- [x] Tests have been added and are passing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
