### PR TITLE
chore: export ConfigureResult interface

### DIFF
--- a/src/configure.d.ts
+++ b/src/configure.d.ts
@@ -43,7 +43,7 @@ interface BinarySettings {
   contentTypes?: string[];
 }
 
-interface ConfigureResult<TEvent = any, TResult = any> {
+export interface ConfigureResult<TEvent = any, TResult = any> {
   handler: Handler<TEvent, TResult>;
   log: Logger;
   proxy: (proxyParams: ProxyParams) => Promise<Object>;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Before exporting the ConfigureResult interface, code would raise TS4023: Exported variable 'handle' has or is using name 'ConfigureResult' from external module "@vendia/serverless-express/src/configure" but cannot be named.

After exporting the ConfigureResult interface, the error goes away.

Before:
<img width="550" alt="image" src="https://user-images.githubusercontent.com/245688/204390936-9bf6ab25-3381-46e3-9122-ad169d31f511.png">

After:
<img width="707" alt="image" src="https://user-images.githubusercontent.com/245688/204391020-8141ec8a-caaf-475e-bcc3-e523a60b64cc.png">

# Checklist

- [ ] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
