### PR TITLE
fix : AWS_EVENTBRIDGE 404

### DIFF
--- a/src/transport.js
+++ b/src/transport.js
@@ -151,6 +151,8 @@ async function forwardRequestToNodeServer ({
   if (!requestValues.path && eventSourceRoutes[eventSourceName]) {
     requestValues.path = eventSourceRoutes[eventSourceName]
   }
+  // Handle Event like as AWS_EVENTBRIDGE (Lambda getting closed with 404)
+  requestValues.path= requestValues.path  || '*'
 
   log.debug('SERVERLESS_EXPRESS:FORWARD_REQUEST_TO_NODE_SERVER:REQUEST_VALUES', { requestValues })
   const { request, response } = await getRequestResponse(requestValues)


### PR DESCRIPTION
*Issue #, if available:*
Lambda is getting closed with 404 for trigger from eventbridge. I am not sure this is correct way or not.

*Description of changes:*
added path handler.

# Checklist

- [ ] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
