### PR TITLE
perf(logger): defer execution of expensive logging calls

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
     expect: true,
     describe: true,
     beforeEach: true,
+    afterEach: true,
     jest: true
   }
 }

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -4,6 +4,7 @@ const express = require('express')
 const bodyParser = require('body-parser')
 const ejs = require('ejs').__express
 const serverlessExpress = require('../src/index')
+const serverlessExpressLogger = require('../src/logger')
 const {
   makeEvent,
   makeResponse,
@@ -445,39 +446,75 @@ describe.each(EACH_MATRIX)('%s:%s: integration tests', (eventSourceName, framewo
     expect(response).toEqual(expectedResponse)
   })
 
-  test('custom logger', async () => {
-    app = express()
-    router = express.Router()
-    app.use('/', router)
-    router.get('/users', (req, res) => {
-      res.json({})
+  describe('logger', () => {
+    const mocks = []
+
+    beforeEach(() => {
+      const mockMethods = [
+        'error',
+        'info',
+        'warn',
+        'log',
+        'debug'
+      ]
+
+      for (const method of mockMethods) { mocks.push(jest.spyOn(global.console, method).mockImplementation()) }
     })
-    const event = makeEvent({
-      eventSourceName,
-      path: '/users',
-      httpMethod: 'GET'
+
+    afterEach(() => {
+      for (const mock of mocks) mock.mockRestore()
     })
-    const customLogger = {
-      error: jest.fn(),
-      warn: jest.fn(),
-      info: jest.fn(),
-      verbose: jest.fn(),
-      debug: jest.fn()
-    }
-    serverlessExpressInstance = serverlessExpress({ app, log: customLogger })
-    await serverlessExpressInstance(event)
 
-    expect(customLogger.debug.mock.calls.length).toBe(6)
+    test('custom logger', async () => {
+      app = express()
+      router = express.Router()
+      app.use('/', router)
+      router.get('/users', (req, res) => {
+        res.json({})
+      })
+      const event = makeEvent({
+        eventSourceName,
+        path: '/users',
+        httpMethod: 'GET'
+      })
+      const customLogger = {
+        error: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn()
+      }
+      serverlessExpressInstance = serverlessExpress({ app, log: customLogger })
+      await serverlessExpressInstance(event)
 
-    // TODO: test log levels
-    // customLogger.level = 'error'
-    // customLogger.debug.mockClear()
-    // customLogger.debug.mockReset()
-    // customLogger.debug = jest.fn()
+      expect(customLogger.debug.mock.calls.length).toBe(6)
 
-    // serverlessExpressInstance = serverlessExpress({ app, log: customLogger })
-    // await serverlessExpressInstance(event)
-    // expect(customLogger.debug.mock.calls.length).toBe(0)
+      // TODO: test log levels
+      // customLogger.level = 'error'
+      // customLogger.debug.mockClear()
+      // customLogger.debug.mockReset()
+      // customLogger.debug = jest.fn()
+
+      // serverlessExpressInstance = serverlessExpress({ app, log: customLogger })
+      // await serverlessExpressInstance(event)
+      // expect(customLogger.debug.mock.calls.length).toBe(0)
+    })
+
+    test('lazy print of logger', async () => {
+      const logger = serverlessExpressLogger()
+
+      logger.debug('debug', () => '=true', ' works')
+      logger.debug(() => 'debug')
+
+      expect(global.console.debug).not.toHaveBeenNthCalledWith(
+        1,
+        'debug=true works'
+      )
+      expect(global.console.debug).not.toHaveBeenNthCalledWith(
+        2,
+        'debug'
+      )
+    })
   })
 
   test('legacy/deprecated createServer', async () => {

--- a/src/configure.js
+++ b/src/configure.js
@@ -43,14 +43,14 @@ function configure ({
     log = configureLog,
     respondWithErrors = configureRespondWithErrors
   }) {
-    log.debug('SERVERLESS_EXPRESS:PROXY', {
+    log.debug('SERVERLESS_EXPRESS:PROXY', () => ({
       event: util.inspect(event, { depth: null }),
       context: util.inspect(context, { depth: null }),
       resolutionMode,
       eventSourceName,
       binarySettings,
       respondWithErrors
-    })
+    }))
 
     if (binaryMimeTypes) {
       console.warn('[DEPRECATION NOTICE] { binaryMimeTypes: [] } is deprecated. base64 encoding is now automatically determined based on response content-type and content-encoding. If you need to manually set binary content types, instead, use { binarySettings: { contentTypes: [] } }')

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,40 +1,46 @@
+const lazyPrint = (value) => {
+  if (typeof value === 'function') { return value() }
+
+  return value
+}
+
 function logger ({
   level = 'error'
 } = {}) {
   return {
-    error (message, additional) {
+    error (message, ...additional) {
       if (!level.includes('debug', 'verbose', 'info', 'warn', 'error')) return
       console.error({
-        message,
-        ...additional
+        message: lazyPrint(message),
+        ...additional.map(lazyPrint)
       })
     },
-    warn (message, additional) {
+    warn (message, ...additional) {
       if (!level.includes('debug', 'verbose', 'info', 'warn')) return
       console.warn({
-        message,
-        ...additional
+        message: lazyPrint(message),
+        ...additional.map(lazyPrint)
       })
     },
     info (message, additional) {
       if (!level.includes('debug', 'verbose', 'info')) return
       console.info({
-        message,
-        ...additional
+        message: lazyPrint(message),
+        ...additional.map(lazyPrint)
       })
     },
     verbose (message, additional) {
       if (!level.includes('debug', 'verbose')) return
       console.debug({
-        message,
-        ...additional
+        message: lazyPrint(message),
+        ...additional.map(lazyPrint)
       })
     },
     debug (message, additional) {
       if (level !== 'debug') return
       console.debug({
-        message,
-        ...additional
+        message: lazyPrint(message),
+        ...additional.map(lazyPrint)
       })
     }
   }

--- a/src/transport.js
+++ b/src/transport.js
@@ -39,10 +39,10 @@ function forwardResponse ({
     response
   })
 
-  log.debug('SERVERLESS_EXPRESS:FORWARD_RESPONSE:EVENT_SOURCE_RESPONSE', {
+  log.debug('SERVERLESS_EXPRESS:FORWARD_RESPONSE:EVENT_SOURCE_RESPONSE', () => ({
     successResponse: util.inspect(successResponse, { depth: null }),
     body: logBody
-  })
+  }))
 
   resolver.succeed({
     response: successResponse


### PR DESCRIPTION
Fixes #613 

*Description of changes:*

The calls of `util.inspect` is very expensive to run, so I defer the execution of the logging by passing a function, inside the logger, I check if is a function then I execute it to get the value.

This could introduce a breaking change if someone overrides the logging library, so the logs that are functions will not be evaluated correctly, but this is the logging of the internal library so I don't know if configures a breaking change.

Another approach to fix the issue is using the variable `logSettings.level` and guarding the log calls by checking if the `level` is equal to `debug`. But this approach makes us pass the `logSettings` to all functions that use `log`, so I don't know either if is a good fixing.

Let me know what you think about the current solution, if don't worth the little breaking change, I can try to modify to use guards with `logSettings`.

To summarize the improvements, below we have the number of op/s in the old version:

```md
╔════════════════════════════╤═════════╤════════════════╤═══════════╗
║ Slower tests               │ Samples │         Result │ Tolerance ║
╟────────────────────────────┼─────────┼────────────────┼───────────╢
║ @vendia/serverless-express │    6000 │ 4554.98 op/sec │  ± 0.98 % ║
║ @h4ad/serverless-adapter   │   10000 │ 8044.64 op/sec │  ± 1.28 % ║
╟────────────────────────────┼─────────┼────────────────┼───────────╢
║ Fastest test               │ Samples │         Result │ Tolerance ║
╟────────────────────────────┼─────────┼────────────────┼───────────╢
║ serverless-http            │   10000 │ 8358.99 op/sec │  ± 1.41 % ║
╚════════════════════════════╧═════════╧════════════════╧═══════════╝
```

Now, this is the number of op/s:

```md
╔════════════════════════════╤═════════╤════════════════╤═══════════╗
║ Slower tests               │ Samples │         Result │ Tolerance ║
╟────────────────────────────┼─────────┼────────────────┼───────────╢
║ @h4ad/serverless-adapter   │   10000 │ 7992.08 op/sec │  ± 1.39 % ║
║ @vendia/serverless-express │   10000 │ 8022.61 op/sec │  ± 1.37 % ║
╟────────────────────────────┼─────────┼────────────────┼───────────╢
║ Fastest test               │ Samples │         Result │ Tolerance ║
╟────────────────────────────┼─────────┼────────────────┼───────────╢
║ serverless-http            │   10000 │ 8342.22 op/sec │  ± 1.43 % ║
╚════════════════════════════╧═════════╧════════════════╧═══════════╝
```

> I run the tests using the benchmark of my library, which you can find [here](https://github.com/H4ad/serverless-adapter/tree/main/benchmark)

# Checklist

- [x] Tests have been added and are passing
- [x] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
