### PR TITLE
fix: unescape plus in ALB query string

### DIFF
--- a/src/event-sources/aws/alb.js
+++ b/src/event-sources/aws/alb.js
@@ -13,13 +13,13 @@ function getPathWithQueryStringUseUnescapeParams ({
   // decode everything back into utf-8 text.
   if (event.multiValueQueryStringParameters) {
     for (const key in event.multiValueQueryStringParameters) {
-      const formattedKey = decodeURIComponent(key)
-      query[formattedKey] = event.multiValueQueryStringParameters[key].map(value => decodeURIComponent(value))
+      const formattedKey = decodeUrlencoded(key)
+      query[formattedKey] = event.multiValueQueryStringParameters[key].map(value => decodeUrlencoded(value))
     }
   } else {
     for (const key in event.queryStringParameters) {
-      const formattedKey = decodeURIComponent(key)
-      query[formattedKey] = decodeURIComponent(event.queryStringParameters[key])
+      const formattedKey = decodeUrlencoded(key)
+      query[formattedKey] = decodeUrlencoded(event.queryStringParameters[key])
     }
   }
 
@@ -27,6 +27,11 @@ function getPathWithQueryStringUseUnescapeParams ({
     pathname: path.replace(replaceRegex, ''),
     query
   })
+}
+
+// Decode an "application/x-www-form-urlencoded" encoded string.
+function decodeUrlencoded (val) {
+  return decodeURIComponent(val.replace(/\+/g, '%20'))
 }
 
 const getRequestValuesFromAlbEvent = ({ event }) => {


### PR DESCRIPTION
#219, #552:

Decode `+` in a query string as a space.

Spaces in a query string are represented with a plus sign, but `decodeURIComponent` does not decode the plus as a space - it has to be done as a separate step. See also: https://url.spec.whatwg.org/#urlencoded-parsing

# Checklist

- [ ] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
