### PR TITLE
Use nullish coalescing to determine path

### DIFF
--- a/src/event-sources/utils.js
+++ b/src/event-sources/utils.js
@@ -4,7 +4,7 @@ function getPathWithQueryStringParams ({
   event,
   query = event.multiValueQueryStringParameters,
   // NOTE: Use `event.pathParameters.proxy` if available ({proxy+}); fall back to `event.path`
-  path = (event.pathParameters && event.pathParameters.proxy && `/${event.pathParameters.proxy}`) || event.path,
+  path = (event.pathParameters && event.pathParameters.proxy && `/${event.pathParameters.proxy}`) ?? event.path,
   // NOTE: Strip base path for custom domains
   stripBasePath = '',
   replaceRegex = new RegExp(`^${stripBasePath}`)


### PR DESCRIPTION
*Issue #, if available:*
We are currently struggling with a situation where `/test` proxies to a lambda. This causes `event.pathParameters.proxy` to be `undefined`. The request is then translated to `/test` rather than `/`.

*Description of changes:*
To solve this we want to overwrite `event.pathParameters.proxy` with an empty string but the absence of nullish coalescing causes this to still use the `event.path` rather than `event.pathParameters.proxy`

# Checklist

- [x] Tests have been added and are passing
- [x] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
