### PR TITLE
feat: add support for eventbridge customer events

### DIFF
--- a/__tests__/unit.eventbridge.js
+++ b/__tests__/unit.eventbridge.js
@@ -1,7 +1,7 @@
 const eventSources = require('../src/event-sources')
 const testUtils = require('./utils')
 
-const dynamodbEventSource = eventSources.getEventSource({
+const eventbridgeEventSource = eventSources.getEventSource({
   eventSourceName: 'AWS_EVENTBRIDGE'
 })
 
@@ -21,7 +21,15 @@ test('request is correct (scheduled)', () => {
   expect(req.method).toEqual('POST')
 })
 
+test('request is correct (customer event)', () => {
+  const req = getReq({ event: testUtils.eventbridgeCustomerEvent })
+  expect(typeof req).toEqual('object')
+  expect(req.headers).toEqual({ host: 'events.amazonaws.com' })
+  expect(req.body).toEqual(testUtils.eventbridgeCustomerEvent)
+  expect(req.method).toEqual('POST')
+})
+
 function getReq ({ event }) {
-  const request = dynamodbEventSource.getRequest({ event })
+  const request = eventbridgeEventSource.getRequest({ event })
   return request
 }

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -194,6 +194,21 @@ const eventbridgeScheduledEvent = {
   resources: ['arn:aws:events:us-east-2:123456789012:rule/my-schedule']
 }
 
+const eventbridgeCustomerEvent = {
+  version: '0',
+  id: 'fe8d3c65-xmpl-c5c3-2c87-81584709a377',
+  source: 'com.mycompany.myapp',
+  account: '123456789012',
+  time: '2016-01-14T01:02:03Z',
+  region: 'us-east-2',
+  resources: [
+    'resource1',
+    'resource2'
+  ],
+  'detail-type': 'myDetailType',
+  detail: {}
+}
+
 // Sample event from https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis-example.html
 const kinesisDataStreamEvent = {
   Records: [
@@ -257,6 +272,11 @@ describe('getEventSourceNameBasedOnEvent', () => {
     const result = getEventSourceNameBasedOnEvent({ event: eventbridgeScheduledEvent })
     expect(result).toEqual('AWS_EVENTBRIDGE')
   })
+
+  test('recognizes eventbridge customer event', () => {
+    const result = getEventSourceNameBasedOnEvent({ event: eventbridgeCustomerEvent })
+    expect(result).toEqual('AWS_EVENTBRIDGE')
+  })
 })
 
 module.exports = {
@@ -266,5 +286,6 @@ module.exports = {
   sqsEvent,
   eventbridgeEvent,
   eventbridgeScheduledEvent,
+  eventbridgeCustomerEvent,
   kinesisDataStreamEvent
 }

--- a/src/event-sources/utils.js
+++ b/src/event-sources/utils.js
@@ -112,7 +112,6 @@ function getEventSourceNameBasedOnEvent ({
     event.id &&
     event['detail-type'] &&
     event.source &&
-    event.source.startsWith('aws.') && // Might need to adjust this for "Partner Sources", e.g. Auth0, Datadog, etc
     event.account &&
     event.time &&
     event.region &&


### PR DESCRIPTION
*Issue #, if available:* #675

*Description of changes:*

Removed the check for an `.aws` prefix in the `source` property when detecting eventbridge as the event source.

This allows customer generated events (ex `source: com.mycompany.myapp`) to be detected as eventbridge events alongside the AWS service events (ex `source: aws.rds`)

# Checklist

- [x] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
