### PR TITLE
Lower case request headers

### DIFF
--- a/__tests__/unit.api-gateway-v1.js
+++ b/__tests__/unit.api-gateway-v1.js
@@ -1,0 +1,21 @@
+const eventSources = require('../src/event-sources')
+const testUtils = require('./utils')
+
+const apiGatewayEventSource = eventSources.getEventSource({
+  eventSourceName: 'AWS_API_GATEWAY_V1'
+})
+
+test('request has correct headers', () => {
+  const req = getReq()
+  // see https://github.com/CodeGenieApp/serverless-express/issues/387
+  expect(typeof req).toEqual('object')
+  expect(JSON.stringify(req.headers)).toEqual(
+    '{"accept":"application/json","content-type":"application/json","content-length":22}'
+  )
+})
+
+function getReq () {
+  const event = testUtils.apiGatewayV1Event
+  const request = apiGatewayEventSource.getRequest({ event })
+  return request
+}

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -1,5 +1,22 @@
 const { getEventSourceNameBasedOnEvent } = require('../src/event-sources/utils')
 
+const apiGatewayV1Event = {
+  headers: {
+    Accept: 'application/json',
+    'Content-Type': 'application/json'
+  },
+  resource: '/',
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  body: '{"test":"1","value":2}',
+  path: '/',
+  pathParameters: {
+    path: '/'
+  },
+  httpMethod: 'GET',
+  requestContext: {}
+}
+
 /**
 This is an event delivered by `sam local start-api`,
 using Type:HttpApi, with SAM CLI version 1.18.0.
@@ -238,6 +255,11 @@ describe('getEventSourceNameBasedOnEvent', () => {
     )
   })
 
+  test('recognizes API Gateway V1 event', () => {
+    const result = getEventSourceNameBasedOnEvent({ event: apiGatewayV1Event })
+    expect(result).toEqual('AWS_API_GATEWAY_V1')
+  })
+
   test('recognizes sam local HttpApi event', () => {
     const result = getEventSourceNameBasedOnEvent({ event: samHttpApiEvent })
     expect(result).toEqual('AWS_API_GATEWAY_V2')
@@ -280,6 +302,7 @@ describe('getEventSourceNameBasedOnEvent', () => {
 })
 
 module.exports = {
+  apiGatewayV1Event,
   samHttpApiEvent,
   dynamoDbEvent,
   snsEvent,

--- a/src/event-sources/utils.js
+++ b/src/event-sources/utils.js
@@ -33,7 +33,9 @@ function getRequestValuesFromEvent ({
   if (event.multiValueHeaders) {
     headers = getCommaDelimitedHeaders({ headersMap: event.multiValueHeaders, lowerCaseKey: true })
   } else if (event.headers) {
-    headers = event.headers
+    Object.entries(event.headers).forEach(([headerKey, headerValue]) => {
+      headers[headerKey.toLowerCase()] = headerValue
+    })
   }
 
   let body


### PR DESCRIPTION
*Issue #, if available:*
Fixes:
#347 

Possibly fixes:
#654 

*Description of changes:*
When a request comes in as an API Gateway V1 request, the request headers get passed down as-is. If we are trying to make the req object look like a Node.js HTTP request object, then it should probably include the logic to lower-case all the HTTP headers. Even though we are satisfying the shape of an HTTP object, we aren't satisfying the behavior.

https://nodejs.org/api/http.html#messageheaders

# Checklist

- [x] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
