### PR TITLE
Lower case request headers (option 2)

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -17,7 +17,12 @@ module.exports = class ServerlessRequest extends http.IncomingMessage {
 
     // IncomingMessage has a lot of logic for when to lowercase or alias well-known header names,
     // so we delegate to that logic here
-    const rawHeaders = Object.entries(headers).flat()
+    const headerEntries = Object.entries(headers)
+    const rawHeaders = new Array(headerEntries.length * 2)
+    for (let i = 0; i < headerEntries.length; i++) {
+      rawHeaders[i * 2] = headerEntries[i][0]
+      rawHeaders[i * 2 + 1] = headerEntries[i][1]
+    }
     this._addHeaderLines(rawHeaders, rawHeaders.length)
 
     Object.assign(this, {

--- a/src/request.js
+++ b/src/request.js
@@ -15,6 +15,11 @@ module.exports = class ServerlessRequest extends http.IncomingMessage {
       destroy: Function.prototype
     })
 
+    // IncomingMessage has a lot of logic for when to lowercase or alias well-known header names,
+    // so we delegate to that logic here
+    const rawHeaders = Object.entries(headers).flat()
+    this._addHeaderLines(rawHeaders, rawHeaders.length)
+
     Object.assign(this, {
       ip: remoteAddress,
       complete: true,
@@ -22,7 +27,6 @@ module.exports = class ServerlessRequest extends http.IncomingMessage {
       httpVersionMajor: '1',
       httpVersionMinor: '1',
       method,
-      headers,
       body,
       url
     })


### PR DESCRIPTION
This is an alternative implementation to #680

*Issue #, if available:*

Fixes:
#347

Possibly fixes:
#654

*Description of changes:*

When a request comes in as an API Gateway V1 request, the request headers get passed down as-is. If we are trying to make the req object look like a Node.js HTTP request object, then it should probably include the logic to lower-case all the HTTP headers. Even though we are satisfying the shape of an HTTP object, we aren't satisfying the behavior.

https://nodejs.org/api/http.html#messageheaders

This approach leverages the underlying implementation of `http.IncomingMessage`, to capture more of the same behavior. Behavior such as lowercasing the header names, joining ones that have duplicates (only technically possible through serverless-express if they differ by case), and providing `headersDistinct` and `rawHeaders` in addition to just `headers`.

# Checklist

- [x] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.