### PR TITLE
Defer marking request as completed until response is complete

### DIFF
--- a/src/transport.js
+++ b/src/transport.js
@@ -160,8 +160,8 @@ async function forwardRequestToNodeServer ({
   log.debug('SERVERLESS_EXPRESS:FORWARD_REQUEST_TO_NODE_SERVER:REQUEST_VALUES', { requestValues })
   const { request, response } = await getRequestResponse(requestValues)
   await framework.sendRequest({ app, request, response })
-  markHttpRequestAsCompleted(request)
   await waitForStreamComplete(response)
+  markHttpRequestAsCompleted(request)
   log.debug('SERVERLESS_EXPRESS:FORWARD_REQUEST_TO_NODE_SERVER:RESPONSE', { response })
   forwardResponse({
     binarySettings,


### PR DESCRIPTION
*Issue #, if available:* #693

*Description of changes:*

Defer marking request as completed until response is complete

Marking the request as complete before the response is finished causes issues if the request is still being read to create the response.

# Checklist

- [ ] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
