### PR TITLE
fix: ensure alb response header values are strings

### DIFF
--- a/__tests__/integration-alb.js
+++ b/__tests__/integration-alb.js
@@ -1,0 +1,37 @@
+const express = require('express')
+const serverlessExpress = require('../src/index')
+const {
+  makeEvent,
+  makeResponse
+} = require('../jest-helpers')
+
+describe('alb:express integration tests', () => {
+  test('reasponse headers are of type string', async () => {
+    const app = express()
+    const router = express.Router()
+    app.use('/', router)
+    const serverlessExpressInstance = serverlessExpress({ app })
+    router.get('/foo', (req, res) => {
+      res.send('123')
+    })
+    const event = makeEvent({
+      eventSourceName: 'alb',
+      path: '/foo',
+      httpMethod: 'GET',
+      headers: {}
+    })
+    const response = await serverlessExpressInstance(event)
+    const expectedResponse = makeResponse({
+      eventSourceName: 'alb',
+      body: '123',
+      headers: {
+        'content-length': '3',
+        'content-type': 'text/html; charset=utf-8',
+        'x-powered-by': 'Express',
+        etag: 'W/"3-QL0AFWMIX8NRZTKeof9cXsvbvu8"'
+      },
+      multiValueHeaders: undefined
+    })
+    expect(response).toMatchObject(expectedResponse)
+  })
+})

--- a/src/event-sources/aws/alb.js
+++ b/src/event-sources/aws/alb.js
@@ -52,7 +52,7 @@ const getResponseToAlb = ({
   const multiValueHeaders = !event.headers ? getMultiValueHeaders({ headers: responseHeaders }) : undefined
   const headers = event.headers
     ? Object.entries(responseHeaders).reduce((acc, [k, v]) => {
-      acc[k] = Array.isArray(v) ? v[0] : v
+      acc[k] = Array.isArray(v) ? String(v[0]) : String(v)
       return acc
     }, {})
     : undefined


### PR DESCRIPTION
There are two open issues surrounding issues with ALB when response header values such as 'content-length' are not strings. This results in a 502 response from ALB. We have also encountered this problem and can confirm this change fixes this issue. 
https://github.com/CodeGenieApp/serverless-express/issues/563
https://github.com/CodeGenieApp/serverless-express/issues/688

*Description of changes:*
This change converts all response header values to strings. A change was already made in [this PR](https://github.com/CodeGenieApp/serverless-express/pull/474) to convert all multipart headers to strings but the normal headers property was missed.

# Checklist

- [x] Tests have been added and are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
