### PR TITLE
fix: response.write() to return a bool (resolves #683)

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -125,6 +125,11 @@ module.exports = class ServerlessResponse extends http.ServerResponse {
         if (typeof cb === 'function') {
           cb()
         }
+
+        // must return bool to indicate if the data was flushed to the
+        // kernel and if not then indicate that the sender must wait
+        // for drain event; which we never do so always return true.
+        return true;
       }
     })
   }


### PR DESCRIPTION
Returning 'false'y tells the sender they need to wait for the 'drain' event which can cause middleware to hang (eg. SvelteKit adapter-node and trpc)

Original fix from @KATT in https://github.com/KATT/serverless-express/commit/9ba260ec7148d81a7caf2db84e62a1ba38b61925

*Issue #683:*

Make response.write() return a bool (always 'true') to prevent middleware stalling waiting for a non-existent `drain` event.

*Description of changes:*

...added `return true`. :)

# Checklist

- [X] Tests ~have been added and~ are passing
- [ ] Documentation has been updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
