### PR TITLE
fix(request): use PassThrough as socket for IncomingMessage

### DIFF
--- a/__tests__/unit.js
+++ b/__tests__/unit.js
@@ -168,6 +168,14 @@ test('getRequestResponse: without headers', async () => {
   })
 })
 
+test('ServerlessRequest socket exposes EventEmitter methods', async () => {
+  const { request } = await getReqRes()
+  expect(typeof request.socket.on).toBe('function')
+  expect(typeof request.socket.once).toBe('function')
+  expect(typeof request.socket.emit).toBe('function')
+  expect(typeof request.socket.removeListener).toBe('function')
+})
+
 describe('respondToEventSourceWithError', () => {
   test('responds with 500 status', () => {
     return new Promise(

--- a/src/request.js
+++ b/src/request.js
@@ -1,19 +1,19 @@
 // ATTRIBUTION: https://github.com/dougmoscrop/serverless-http
 
 const http = require('http')
+const { PassThrough } = require('stream')
 
 const HTTPS_PORT = 443
 
 module.exports = class ServerlessRequest extends http.IncomingMessage {
   constructor ({ method, url, headers, body, remoteAddress }) {
-    super({
-      encrypted: true,
-      readable: true,
-      remoteAddress,
-      address: () => ({ port: HTTPS_PORT }),
-      end: Function.prototype,
-      destroy: Function.prototype
-    })
+    const socket = new PassThrough()
+    socket.encrypted = true
+    socket.readable = true
+    socket.remoteAddress = remoteAddress
+    socket.address = () => ({ port: HTTPS_PORT })
+
+    super(socket)
 
     // IncomingMessage has a lot of logic for when to lowercase or alias well-known header names,
     // so we delegate to that logic here


### PR DESCRIPTION
## Problem

`@codegenie/serverless-express` >= 4.16.0 with Express 5 throws `TypeError: ee.on is not a function` whenever a request reaches Express's `finalhandler` (e.g. unmatched routes). Reported in #698; still present in v5.0.0.

Stack from production:

```
TypeError: ee.on is not a function
    at first (ee-first/index.js:43:10)
    at onSocket (on-finished/index.js:115:16)
    at attachFinishedListener (on-finished/index.js:120:5)
    ...
    at send (finalhandler/index.js:291:3)
```

## Root cause

`ServerlessRequest` (`src/request.js`) extends `http.IncomingMessage` and passes a plain object as the socket. When Express 5's `finalhandler` reaches an unmatched route and the request body wasn't consumed (typical for GETs), it calls `onFinished(req)`, which uses `ee-first` to attach `error` and `close` listeners on `req.socket`. The plain object has no `.on`, so it throws.

## Fix

Use a `PassThrough` stream as the socket. PassThrough inherits the EventEmitter interface via Duplex/Stream, so `.on`, `.once`, `.emit`, and `.removeListener` are all present. The `end`/`destroy` `Function.prototype` stubs are dropped since PassThrough provides real implementations.

This is the same fix that landed upstream in [`dougmoscrop/serverless-http#306`](https://github.com/dougmoscrop/serverless-http/pull/306) (merged Sep 2025), the library this file was forked from per the attribution comment at the top.

Closes #698